### PR TITLE
feat: add onboarding intro screens at app startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ class SaatDinApp extends StatelessWidget {
       title: 'SaatDin',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.lightTheme,
-      initialRoute: AppRoutes.welcome,
+      initialRoute: AppRoutes.onboarding,
       routes: AppRoutes.routes,
     );
   }

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../screens/onboarding/onboarding_screen.dart';
 import '../screens/welcome_screen.dart';
 import '../screens/onboarding/platform_selection_screen.dart';
 import '../screens/onboarding/plan_selection_screen.dart';
@@ -7,6 +8,7 @@ import '../screens/main_shell.dart';
 class AppRoutes {
   AppRoutes._();
 
+  static const String onboarding = '/onboarding';
   static const String welcome = '/welcome';
   static const String platformSelect = '/platform-select';
   static const String planSelect = '/plan-select';
@@ -14,6 +16,7 @@ class AppRoutes {
 
   static Map<String, WidgetBuilder> get routes {
     return {
+      onboarding: (context) => const OnboardingScreen(),
       welcome: (context) => const WelcomeScreen(),
       platformSelect: (context) => const PlatformSelectionScreen(),
       planSelect: (context) => const PlanSelectionScreen(),

--- a/lib/screens/onboarding/onboarding_screen.dart
+++ b/lib/screens/onboarding/onboarding_screen.dart
@@ -1,0 +1,402 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
+import '../../theme/app_colors.dart';
+import '../../routes/app_routes.dart';
+
+/// Data model for a single onboarding slide.
+class _OnboardingSlide {
+  final IconData icon;
+  final Color iconColor;
+  final Color iconBg;
+  final String headline;
+  final String subheadline;
+  final String body;
+
+  const _OnboardingSlide({
+    required this.icon,
+    required this.iconColor,
+    required this.iconBg,
+    required this.headline,
+    required this.subheadline,
+    required this.body,
+  });
+}
+
+const List<_OnboardingSlide> _slides = [
+  _OnboardingSlide(
+    icon: Icons.electric_bolt_rounded,
+    iconColor: Color(0xFF2EC4B6),
+    iconBg: Color(0xFFE0F7F5),
+    headline: 'Zero-Touch Payouts',
+    subheadline: 'No forms. No calls. No waiting.',
+    body:
+        'When heavy rain, floods, or severe traffic shut down your delivery zone, '
+        'SaatDin detects it automatically and sends money straight to your UPI — '
+        'usually before you even reach home.',
+  ),
+  _OnboardingSlide(
+    icon: Icons.my_location_rounded,
+    iconColor: Color(0xFF0D4B3C),
+    iconBg: Color(0xFFD1FAE5),
+    headline: 'Pincode-Precise Coverage',
+    subheadline: 'Your zone. Your payout.',
+    body:
+        'Disruptions are tracked at the pincode level. A flood in Bellandur '
+        "doesn't trigger a payout for a rider in Whitefield. "
+        'Coverage is always relevant to exactly where you work.',
+  ),
+  _OnboardingSlide(
+    icon: Icons.currency_rupee_rounded,
+    iconColor: Color(0xFFF59E0B),
+    iconBg: Color(0xFFFEF3C7),
+    headline: 'Weekly Premium, Big Safety Net',
+    subheadline: 'From ₹29 / week.',
+    body:
+        'Pay a small weekly premium — auto-debited every Monday via UPI. '
+        'Get up to ₹500 back for every qualifying disruption day. '
+        'Cancel anytime, no lock-in.',
+  ),
+];
+
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen>
+    with TickerProviderStateMixin {
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  // Per-page animation controllers
+  late final List<AnimationController> _slideControllers;
+  late final List<Animation<double>> _fadeAnims;
+  late final List<Animation<Offset>> _slideAnims;
+
+  @override
+  void initState() {
+    super.initState();
+    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark);
+
+    _slideControllers = List.generate(
+      _slides.length,
+      (_) => AnimationController(
+        vsync: this,
+        duration: const Duration(milliseconds: 500),
+      ),
+    );
+
+    _fadeAnims = _slideControllers
+        .map(
+          (c) => CurvedAnimation(parent: c, curve: Curves.easeOut),
+        )
+        .toList();
+
+    _slideAnims = _slideControllers
+        .map(
+          (c) => Tween<Offset>(
+            begin: const Offset(0, 0.12),
+            end: Offset.zero,
+          ).animate(CurvedAnimation(parent: c, curve: Curves.easeOut)),
+        )
+        .toList();
+
+    // Animate the first slide in immediately
+    _slideControllers[0].forward();
+  }
+
+  @override
+  void dispose() {
+    for (final c in _slideControllers) {
+      c.dispose();
+    }
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _onPageChanged(int page) {
+    setState(() => _currentPage = page);
+    _slideControllers[page].forward(from: 0);
+  }
+
+  void _goToNext() {
+    if (_currentPage < _slides.length - 1) {
+      _pageController.nextPage(
+        duration: const Duration(milliseconds: 420),
+        curve: Curves.easeInOut,
+      );
+    } else {
+      _navigateToWelcome();
+    }
+  }
+
+  void _navigateToWelcome() {
+    Navigator.pushReplacementNamed(context, AppRoutes.welcome);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Column(
+          children: [
+            // ── Skip button ────────────────────────────────────────
+            Align(
+              alignment: Alignment.topRight,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 12, right: 20),
+                child: AnimatedOpacity(
+                  opacity: _currentPage < _slides.length - 1 ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 250),
+                  child: GestureDetector(
+                    onTap: _navigateToWelcome,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 6,
+                      ),
+                      decoration: BoxDecoration(
+                        color: AppColors.surfaceLight,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Text(
+                        'Skip',
+                        style: GoogleFonts.inter(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+
+            // ── Slide pages ────────────────────────────────────────
+            Expanded(
+              child: PageView.builder(
+                controller: _pageController,
+                itemCount: _slides.length,
+                onPageChanged: _onPageChanged,
+                itemBuilder: (context, index) {
+                  final slide = _slides[index];
+                  return FadeTransition(
+                    opacity: _fadeAnims[index],
+                    child: SlideTransition(
+                      position: _slideAnims[index],
+                      child: _SlideContent(
+                        slide: slide,
+                        screenHeight: size.height,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+
+            // ── Bottom area: dots + button ─────────────────────────
+            Padding(
+              padding: const EdgeInsets.fromLTRB(28, 0, 28, 32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Progress dots
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: List.generate(_slides.length, (i) {
+                      final isActive = i == _currentPage;
+                      return AnimatedContainer(
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeOut,
+                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                        width: isActive ? 28 : 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          color: isActive
+                              ? AppColors.accent
+                              : AppColors.border,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      );
+                    }),
+                  ),
+
+                  const SizedBox(height: 28),
+
+                  // Next / Get Started button
+                  SizedBox(
+                    width: double.infinity,
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 300),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(14),
+                        gradient: LinearGradient(
+                          colors: _currentPage == _slides.length - 1
+                              ? [
+                                  AppColors.primary,
+                                  AppColors.primaryLight,
+                                ]
+                              : [
+                                  AppColors.accent,
+                                  const Color(0xFF1DADA0),
+                                ],
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: (_currentPage == _slides.length - 1
+                                    ? AppColors.primary
+                                    : AppColors.accent)
+                                .withValues(alpha: 0.35),
+                            blurRadius: 16,
+                            offset: const Offset(0, 6),
+                          ),
+                        ],
+                      ),
+                      child: Material(
+                        color: Colors.transparent,
+                        borderRadius: BorderRadius.circular(14),
+                        child: InkWell(
+                          onTap: _goToNext,
+                          borderRadius: BorderRadius.circular(14),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 18),
+                            child: Center(
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text(
+                                    _currentPage == _slides.length - 1
+                                        ? 'Get Started'
+                                        : 'Next',
+                                    style: GoogleFonts.inter(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w700,
+                                      color: Colors.white,
+                                      letterSpacing: 0.2,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  const Icon(
+                                    Icons.arrow_forward_rounded,
+                                    color: Colors.white,
+                                    size: 18,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The visual content of one onboarding slide.
+class _SlideContent extends StatelessWidget {
+  final _OnboardingSlide slide;
+  final double screenHeight;
+
+  const _SlideContent({
+    required this.slide,
+    required this.screenHeight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 28),
+      child: Column(
+        children: [
+          SizedBox(height: screenHeight * 0.06),
+
+          // ── Illustration container ──────────────────────────────
+          Container(
+            width: double.infinity,
+            height: screenHeight * 0.34,
+            decoration: BoxDecoration(
+              color: slide.iconBg,
+              borderRadius: BorderRadius.circular(28),
+            ),
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                // Subtle decorative circle behind icon
+                Container(
+                  width: 130,
+                  height: 130,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: slide.iconColor.withValues(alpha: 0.1),
+                  ),
+                ),
+                Icon(
+                  slide.icon,
+                  size: 80,
+                  color: slide.iconColor,
+                ),
+              ],
+            ),
+          ),
+
+          SizedBox(height: screenHeight * 0.045),
+
+          // ── Text content ────────────────────────────────────────
+          Text(
+            slide.headline,
+            textAlign: TextAlign.center,
+            style: GoogleFonts.montserrat(
+              fontSize: 26,
+              fontWeight: FontWeight.w800,
+              color: AppColors.textPrimary,
+              letterSpacing: -0.5,
+              height: 1.2,
+            ),
+          ),
+
+          const SizedBox(height: 8),
+
+          Text(
+            slide.subheadline,
+            textAlign: TextAlign.center,
+            style: GoogleFonts.inter(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: slide.iconColor,
+              letterSpacing: 0.2,
+            ),
+          ),
+
+          const SizedBox(height: 16),
+
+          Text(
+            slide.body,
+            textAlign: TextAlign.center,
+            style: GoogleFonts.inter(
+              fontSize: 15,
+              fontWeight: FontWeight.w400,
+              color: AppColors.textSecondary,
+              height: 1.55,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
@@ -199,18 +199,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -364,10 +364,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:
@@ -417,5 +417,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.4 <4.0.0"
+  dart: ">=3.10.3 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.11.4
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Closes #1

- Add OnboardingScreen with 3 animated feature-explanation slides:
  1. Zero-Touch Payouts  – automatic disruption detection
  2. Pincode-Precise Coverage – zone-level accuracy
  3. Weekly Premium, Big Safety Net – ₹29/week model
- Each slide has fade + slide-in animation, icon illustration, headline, coloured sub-headline, and body copy
- Skip button lets returning users jump straight to login
- Final slide CTA reads 'Get Started' (all others 'Next')
- Animated progress dots track position (reuses the same pill-dot pattern from existing ProgressDots widget)
- Update AppRoutes: add /onboarding route as the new initial route
- Update main.dart: initialRoute changed from /welcome to /onboarding
- Relax SDK constraint to >=3.0.0 <4.0.0 for local dev compatibility