### PR TITLE
Merge local rider UX with upstream phase-3 payment updates

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,6 +26,8 @@ class Settings(BaseSettings):
     waqi_api_key: str = ""
     tomtom_api_key: str = ""
     news_api_key: str = ""
+    external_api_verify_ssl: bool = True
+    external_api_ca_bundle: str = ""
 
     trigger_poll_minutes: int = 15
     trigger_window_sample_slack: int = 1

--- a/backend/app/services/external_apis.py
+++ b/backend/app/services/external_apis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import ssl
 from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, Optional
 
@@ -19,6 +20,16 @@ try:
     import aiohttp
 except ImportError:
     aiohttp = None  # type: ignore
+
+try:
+    import certifi
+except ImportError:
+    certifi = None  # type: ignore
+
+try:
+    import truststore
+except ImportError:
+    truststore = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +63,48 @@ class ExternalAPIClient:
     async def initialize(self):
         """Initialize aiohttp session if available."""
         if self._aiohttp_available:
-            self._session = aiohttp.ClientSession()
+            ssl_context = None
+            if settings.external_api_verify_ssl:
+                ca_path = settings.external_api_ca_bundle.strip()
+                try:
+                    # Default to OS trust store when available (handles enterprise roots on Windows).
+                    if not ca_path:
+                        if truststore is not None:
+                            ssl_context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                            logger.info("external_api_ssl_context=truststore")
+                        elif certifi is not None:
+                            ssl_context = ssl.create_default_context(cafile=certifi.where())
+                            logger.info("external_api_ssl_context=certifi")
+                        else:
+                            ssl_context = ssl.create_default_context()
+                            logger.info("external_api_ssl_context=default")
+                    elif ca_path.lower() == "certifi":
+                        if certifi is None:
+                            logger.warning(
+                                "external_api_certifi_requested_but_missing",
+                            )
+                            ssl_context = ssl.create_default_context()
+                        else:
+                            ssl_context = ssl.create_default_context(
+                                cafile=certifi.where(),
+                            )
+                    else:
+                        ssl_context = ssl.create_default_context(cafile=ca_path)
+                        logger.info("external_api_ssl_context=custom_bundle")
+                except Exception as exc:
+                    logger.warning(
+                        "external_api_ca_bundle_load_failed: %s",
+                        exc,
+                    )
+                    ssl_context = ssl.create_default_context()
+            else:
+                logger.warning(
+                    "external_api_ssl_verification_disabled",
+                )
+                ssl_context = False
+
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            self._session = aiohttp.ClientSession(connector=connector)
 
     async def close(self):
         """Close aiohttp session."""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,8 @@ PyJWT==2.9.0
 asyncpg==0.30.0
 APScheduler==3.10.4
 aiohttp==3.10.1
+certifi==2024.8.30
+truststore==0.10.0
 scikit-learn==1.5.2
 joblib==1.4.2
 httpx==0.28.1

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'theme/app_theme.dart';
+import 'theme/theme_controller.dart';
 import 'routes/app_routes.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await ThemeController.instance.initialize();
   if (!kIsWeb) {
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
@@ -20,12 +22,19 @@ class SaatDinApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'SaatDin',
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.lightTheme,
-      initialRoute: AppRoutes.onboarding,
-      routes: AppRoutes.routes,
+    return AnimatedBuilder(
+      animation: ThemeController.instance,
+      builder: (context, _) {
+        return MaterialApp(
+          title: 'SaatDin',
+          debugShowCheckedModeBanner: false,
+          theme: AppTheme.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          themeMode: ThemeController.instance.themeMode,
+          initialRoute: AppRoutes.onboarding,
+          routes: AppRoutes.routes,
+        );
+      },
     );
   }
 }

--- a/lib/screens/claims/claims_screen.dart
+++ b/lib/screens/claims/claims_screen.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'dart:math' as math;
+import 'dart:async';
+import 'package:showcaseview/showcaseview.dart';
 
 import '../../theme/app_colors.dart';
 import '../../models/claim_model.dart';
 import '../../models/user_model.dart';
 import '../../services/api_service.dart';
+import '../../services/guide_preferences.dart';
 import '../../widgets/claim_card.dart';
 import '../../services/tab_router.dart';
 import 'zone_lock_report_screen.dart';
@@ -19,17 +22,43 @@ class ClaimsScreen extends StatefulWidget {
 
 class _ClaimsScreenState extends State<ClaimsScreen> {
   final ApiService _apiService = ApiService();
+  final GlobalKey _guideSummaryKey = GlobalKey();
   int _selectedTab = 0;
   final _tabs = ['All Claims', 'In Review', 'Settled'];
   List<Claim> _claims = [];
   User? _user;
   Map<String, dynamic>? _policy;
   bool _isLoadingClaims = true;
+  bool _shouldShowGuide = false;
+  bool _guidePreferenceResolved = false;
+  bool _guideStarted = false;
 
   @override
   void initState() {
     super.initState();
     _loadClaims();
+    unawaited(_resolveGuidePreference());
+  }
+
+  Future<void> _resolveGuidePreference() async {
+    final shouldShow = await GuidePreferences.shouldShow(
+      GuidePreferences.claimsGuideSeen,
+    );
+    if (!mounted) return;
+    setState(() {
+      _shouldShowGuide = shouldShow;
+      _guidePreferenceResolved = true;
+    });
+  }
+
+  void _maybeStartGuide(BuildContext context) {
+    if (!_guidePreferenceResolved || !_shouldShowGuide || _guideStarted) return;
+    _guideStarted = true;
+    unawaited(GuidePreferences.markSeen(GuidePreferences.claimsGuideSeen));
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ShowCaseWidget.of(context).startShowCase([_guideSummaryKey]);
+    });
   }
 
   Future<void> _loadClaims() async {
@@ -112,7 +141,7 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
         message.contains('worker not found for token subject');
   }
 
-  Widget _buildTopUtilityButtons(User user) {
+  Widget _buildTopUtilityButtons(User user, {required bool isDark}) {
     final safeName = _coerceString(user.name, fallback: 'U');
 
     return Row(
@@ -121,6 +150,7 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
         _utilityIconButton(
           icon: Icons.arrow_back,
           tooltip: 'Back to Home',
+          isDark: isDark,
           onTap: () {
             _switchToTab(0);
           },
@@ -130,6 +160,7 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
             _utilityIconButton(
               icon: Icons.notifications_none,
               tooltip: 'Notifications',
+              isDark: isDark,
               onTap: () {
                 _showNotificationsSheet();
               },
@@ -170,6 +201,7 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
   Widget _utilityIconButton({
     required IconData icon,
     required String tooltip,
+    required bool isDark,
     required VoidCallback onTap,
   }) {
     return Tooltip(
@@ -181,11 +213,19 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
           width: 42,
           height: 42,
           decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.2),
+            color: isDark
+                ? AppColors.nightSurface.withValues(alpha: 0.92)
+                : Colors.white,
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: Colors.white.withValues(alpha: 0.28)),
+            border: Border.all(
+              color: isDark ? AppColors.nightBorder : AppColors.border,
+            ),
           ),
-          child: Icon(icon, size: 21, color: AppColors.textPrimary),
+          child: Icon(
+            icon,
+            size: 21,
+            color: isDark ? Colors.white : AppColors.textPrimary,
+          ),
         ),
       ),
     );
@@ -195,12 +235,14 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
     switch (_selectedTab) {
       case 1:
         return _claims
-            .where((c) => c.status == ClaimStatus.inReview || c.status == ClaimStatus.escalated)
+            .where(
+              (c) =>
+                  c.status == ClaimStatus.inReview ||
+                  c.status == ClaimStatus.escalated,
+            )
             .toList();
       case 2:
-        return _claims
-            .where((c) => c.status == ClaimStatus.settled)
-            .toList();
+        return _claims.where((c) => c.status == ClaimStatus.settled).toList();
       default:
         return _claims;
     }
@@ -208,306 +250,591 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final pageBackground = isDark
+        ? AppColors.nightBackground
+        : AppColors.scaffoldBackground;
+    final primaryText = isDark ? Colors.white : AppColors.textPrimary;
+    final secondaryText = isDark ? Colors.white70 : AppColors.textSecondary;
+    final chipBackground = isDark
+        ? AppColors.nightSurface
+        : AppColors.cardBackground;
+    final chipBorder = isDark ? AppColors.nightBorder : AppColors.border;
+
     final user = _user;
     final weeklyPremium = (_policy?['weeklyPremium'] as num? ?? 0).toInt();
-    final policyStatus = ((_policy?['status'] as String?) ?? 'active').toUpperCase();
+    final policyStatus = ((_policy?['status'] as String?) ?? 'active')
+        .toUpperCase();
     final inReviewCount = _claims
-        .where((c) => c.status == ClaimStatus.inReview || c.status == ClaimStatus.escalated)
+        .where(
+          (c) =>
+              c.status == ClaimStatus.inReview ||
+              c.status == ClaimStatus.escalated,
+        )
         .length;
+    final settledCount = _claims
+        .where((c) => c.status == ClaimStatus.settled)
+        .length;
+    final pendingCount = _claims
+        .where((c) => c.status == ClaimStatus.pending)
+        .length;
+    final rejectedCount = _claims
+        .where((c) => c.status == ClaimStatus.rejected)
+        .length;
+    final totalClaims = _claims.length;
 
     if (_isLoadingClaims) {
-      return const Scaffold(
-        backgroundColor: AppColors.scaffoldBackground,
-        body: Center(child: CircularProgressIndicator()),
+      return Scaffold(
+        backgroundColor: pageBackground,
+        body: Center(
+          child: CircularProgressIndicator(color: AppColors.neonGreen),
+        ),
       );
     }
 
     if (user == null) {
-      return const Scaffold(
-        backgroundColor: AppColors.scaffoldBackground,
+      return Scaffold(
+        backgroundColor: pageBackground,
         body: Center(
           child: Text(
             'Failed to load claims data.',
-            style: TextStyle(color: AppColors.textSecondary),
+            style: TextStyle(color: secondaryText),
           ),
         ),
       );
     }
 
-    return Scaffold(
-      backgroundColor: AppColors.scaffoldBackground,
-      floatingActionButton: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // ZoneLock quick-report button (Issue #8)
-          Tooltip(
-            message: 'Report ZoneLock',
-            child: FloatingActionButton.small(
-              heroTag: 'fab_zonelock',
-              onPressed: _openZoneLockReport,
-              backgroundColor: AppColors.warning,
-              child: const Icon(Icons.lock_person_outlined, color: Colors.white),
-            ),
-          ),
-          const SizedBox(height: 10),
-          FloatingActionButton(
-            heroTag: 'fab_new_claim',
-            onPressed: () {
-              _showNewClaimSheet();
-            },
-            backgroundColor: AppColors.primary,
-            child: const Icon(Icons.add, color: Colors.white),
-          ),
-        ],
-      ),
-      body: Stack(
-        children: [
-          const Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            child: SizedBox(
-              height: 205,
-              child: CustomPaint(
-                painter: _ClaimsTopBackgroundPainter(),
+    return ShowCaseWidget(
+      builder: (guideContext) {
+        _maybeStartGuide(guideContext);
+        return Scaffold(
+          backgroundColor: pageBackground,
+          floatingActionButton: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Tooltip(
+                message: 'Report ZoneLock',
+                child: FloatingActionButton.small(
+                  heroTag: 'fab_zonelock',
+                  onPressed: _openZoneLockReport,
+                  backgroundColor: AppColors.neonAmber,
+                  child: const Icon(
+                    Icons.lock_person_outlined,
+                    color: Colors.white,
+                  ),
+                ),
               ),
-            ),
+              const SizedBox(height: 10),
+              FloatingActionButton(
+                heroTag: 'fab_new_claim',
+                onPressed: () {
+                  _showNewClaimSheet();
+                },
+                backgroundColor: AppColors.primary,
+                child: Icon(
+                  Icons.add,
+                  color: isDark ? Colors.white : Colors.black,
+                ),
+              ),
+            ],
           ),
-          SafeArea(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const SizedBox(height: 16),
-
-                  _buildTopUtilityButtons(user),
-                  const SizedBox(height: 14),
-
-                  // Header
-                  const Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
+          body: Stack(
+            children: [
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: SizedBox(
+                  height: 205,
+                  child: CustomPaint(
+                    painter: _ClaimsTopBackgroundPainter(isDark: isDark),
+                  ),
+                ),
+              ),
+              SafeArea(
+                child: RefreshIndicator(
+                  color: AppColors.neonGreen,
+                  backgroundColor: isDark
+                      ? AppColors.nightSurface
+                      : AppColors.cardBackground,
+                  onRefresh: _loadClaims,
+                  child: ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
                     children: [
+                      _buildTopUtilityButtons(user, isDark: isDark),
+                      const SizedBox(height: 18),
                       Text(
                         'Claims',
                         style: TextStyle(
-                          fontSize: 28,
-                          fontWeight: FontWeight.w800,
-                          color: AppColors.textPrimary,
-                          letterSpacing: -0.4,
+                          fontSize: 30,
+                          fontWeight: FontWeight.w900,
+                          color: primaryText,
+                          letterSpacing: -0.5,
                         ),
                       ),
-                      SizedBox(height: 4),
+                      const SizedBox(height: 4),
                       Text(
-                        'Track status and settlements',
+                        'Track status, proof, and settlements in one place.',
+                        style: TextStyle(fontSize: 13, color: secondaryText),
+                      ),
+                      const SizedBox(height: 16),
+                      Showcase(
+                        key: _guideSummaryKey,
+                        title: 'Claim Health Snapshot',
+                        description:
+                            'This card gives your active policy status, weekly premium context, and the fastest summary of claim outcomes.',
+                        child: _buildClaimSummaryCard(
+                          context: context,
+                          weeklyPremium: weeklyPremium,
+                          policyStatus: policyStatus,
+                          inReviewCount: inReviewCount,
+                          pendingCount: pendingCount,
+                          settledCount: settledCount,
+                          rejectedCount: rejectedCount,
+                          totalClaims: totalClaims,
+                        ),
+                      ),
+                      const SizedBox(height: 14),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: _claimStatPill(
+                              context: context,
+                              label: 'Pending',
+                              value: pendingCount.toString(),
+                              icon: Icons.schedule_rounded,
+                              color: AppColors.neonAmber,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: _claimStatPill(
+                              context: context,
+                              label: 'In review',
+                              value: inReviewCount.toString(),
+                              icon: Icons.rate_review_outlined,
+                              color: AppColors.neonCyan,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: _claimStatPill(
+                              context: context,
+                              label: 'Settled',
+                              value: settledCount.toString(),
+                              icon: Icons.verified_rounded,
+                              color: AppColors.neonGreen,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 18),
+                      Text(
+                        'Filter',
                         style: TextStyle(
-                          fontSize: 13,
-                          color: AppColors.textSecondary,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w800,
+                          color: primaryText,
                         ),
                       ),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
-
-              // Current protection header
-              Container(
-                width: double.infinity,
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  color: AppColors.primary,
-                  borderRadius: BorderRadius.circular(20),
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'CURRENT PROTECTION',
-                      style: TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w600,
-                        color: Colors.white.withValues(alpha: 0.6),
-                        letterSpacing: 1.2,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          '₹$weeklyPremium',
-                          style: TextStyle(
-                            fontSize: 36,
-                            fontWeight: FontWeight.w800,
-                            color: Colors.white,
-                            letterSpacing: -0.5,
-                          ),
-                        ),
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 10, vertical: 5),
-                          decoration: BoxDecoration(
-                            color: AppColors.success,
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Text(
-                            policyStatus,
-                            style: TextStyle(
-                              fontSize: 10,
+                      const SizedBox(height: 10),
+                      Wrap(
+                        spacing: 10,
+                        runSpacing: 10,
+                        children: _tabs.asMap().entries.map((entry) {
+                          final isSelected = _selectedTab == entry.key;
+                          return ChoiceChip(
+                            label: Text(entry.value),
+                            selected: isSelected,
+                            onSelected: (_) {
+                              setState(() {
+                                _selectedTab = entry.key;
+                              });
+                            },
+                            selectedColor: AppColors.neonGreen.withValues(
+                              alpha: 0.18,
+                            ),
+                            backgroundColor: chipBackground,
+                            labelStyle: TextStyle(
+                              color: isSelected ? primaryText : secondaryText,
                               fontWeight: FontWeight.w700,
-                              color: Colors.white,
-                              letterSpacing: 0.8,
+                            ),
+                            side: BorderSide(
+                              color: isSelected
+                                  ? AppColors.neonGreen.withValues(alpha: 0.32)
+                                  : chipBorder,
+                            ),
+                          );
+                        }).toList(),
+                      ),
+                      const SizedBox(height: 18),
+                      Row(
+                        children: [
+                          Text(
+                            'Recent Activity',
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w800,
+                              color: primaryText,
+                            ),
+                          ),
+                          const Spacer(),
+                          Text(
+                            '${_filteredClaims.length} shown',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: secondaryText,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      if (_filteredClaims.isEmpty)
+                        _buildEmptyClaimsState(context)
+                      else
+                        ..._filteredClaims.map(
+                          (claim) => Padding(
+                            padding: const EdgeInsets.only(bottom: 12),
+                            child: ClaimCard(
+                              claim: claim,
+                              onTap: () => _showClaimDetails(claim),
                             ),
                           ),
                         ),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      '$inReviewCount pending settlements',
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: Colors.white.withValues(alpha: 0.6),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 20),
-
-              const Text(
-                'Filter',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.textPrimary,
-                ),
-              ),
-              const SizedBox(height: 10),
-
-              // Filter tabs
-              Row(
-                children: _tabs.asMap().entries.map((entry) {
-                  final isSelected = _selectedTab == entry.key;
-                  return Padding(
-                    padding: const EdgeInsets.only(right: 8),
-                    child: GestureDetector(
-                      onTap: () {
-                        setState(() {
-                          _selectedTab = entry.key;
-                        });
-                      },
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 10),
-                        decoration: BoxDecoration(
-                          color: isSelected
-                              ? AppColors.primary
-                              : AppColors.surfaceLight,
-                          borderRadius: BorderRadius.circular(24),
-                        ),
-                        child: Text(
-                          entry.value,
-                          style: TextStyle(
-                            fontSize: 13,
-                            fontWeight: FontWeight.w600,
-                            color: isSelected
-                                ? Colors.white
-                                : AppColors.textSecondary,
-                          ),
-                        ),
-                      ),
-                    ),
-                  );
-                }).toList(),
-              ),
-              const SizedBox(height: 20),
-
-              const Text(
-                'Recent Activity',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.textPrimary,
-                ),
-              ),
-              const SizedBox(height: 10),
-
-              // Claims list
-              if (_isLoadingClaims)
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 24),
-                  child: Center(child: CircularProgressIndicator()),
-                )
-              else if (_filteredClaims.isEmpty)
-                Center(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 40),
-                    child: Column(
-                      children: [
-                        const Icon(
-                          Icons.receipt_long_outlined,
-                          size: 48,
-                          color: AppColors.textTertiary,
-                        ),
-                        const SizedBox(height: 12),
-                        const Text(
-                          'No claims in this category',
-                          style: TextStyle(
-                            fontSize: 15,
-                            color: AppColors.textSecondary,
-                          ),
-                        ),
-                      ],
-                    ),
+                      const SizedBox(height: 10),
+                      _buildClaimsHelpCard(context),
+                    ],
                   ),
                 ),
-              for (final claim in _filteredClaims)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 12),
-                  child: ClaimCard(
-                    claim: claim,
-                    onTap: () => _showClaimDetails(claim),
-                  ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildClaimSummaryCard({
+    required BuildContext context,
+    required int weeklyPremium,
+    required String policyStatus,
+    required int inReviewCount,
+    required int pendingCount,
+    required int settledCount,
+    required int rejectedCount,
+    required int totalClaims,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final cardBg = isDark
+        ? AppColors.nightSurface
+        : Theme.of(context).colorScheme.surface;
+    final cardBorder = isDark
+        ? AppColors.nightBorder
+        : Theme.of(context).colorScheme.outline.withValues(alpha: 0.28);
+    final primaryText = Theme.of(context).colorScheme.onSurface;
+    final secondaryText = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.68 : 0.76);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Current protection',
+                style: TextStyle(
+                  color: primaryText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w800,
                 ),
-
-              const SizedBox(height: 16),
-
-              // Need help section
+              ),
+              const Spacer(),
               Container(
-                width: double.infinity,
-                padding: const EdgeInsets.all(20),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
                 decoration: BoxDecoration(
-                  color: AppColors.cardBackground,
-                  borderRadius: BorderRadius.circular(20),
-                  border: Border.all(color: AppColors.border),
+                  color: AppColors.neonGreen.withValues(alpha: 0.16),
+                  borderRadius: BorderRadius.circular(999),
                 ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Text(
-                      'Need help with a claim?',
-                      style: TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.textPrimary,
-                      ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      'Our claim specialists are available 24/7 to assist you in Kannada, Hindi, and English.',
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: AppColors.textSecondary,
-                        height: 1.4,
-                      ),
-                    ),
-                  ],
+                child: Text(
+                  policyStatus,
+                  style: TextStyle(
+                    color: primaryText,
+                    fontSize: 10,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0.8,
+                  ),
                 ),
               ),
-              const SizedBox(height: 24),
-                ],
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                '₹$weeklyPremium',
+                style: TextStyle(
+                  color: primaryText,
+                  fontSize: 34,
+                  fontWeight: FontWeight.w900,
+                  letterSpacing: -0.6,
+                ),
               ),
+              const SizedBox(width: 10),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(
+                  '/ week',
+                  style: TextStyle(color: secondaryText, fontSize: 13),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '$inReviewCount live settlements · $totalClaims claims total',
+            style: TextStyle(color: secondaryText, fontSize: 12),
+          ),
+          const SizedBox(height: 14),
+          Row(
+            children: [
+              Expanded(
+                child: _miniStatusRow(
+                  context: context,
+                  label: 'Pending',
+                  value: pendingCount.toString(),
+                  color: AppColors.neonAmber,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _miniStatusRow(
+                  context: context,
+                  label: 'In review',
+                  value: inReviewCount.toString(),
+                  color: AppColors.neonCyan,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _miniStatusRow(
+                  context: context,
+                  label: 'Settled',
+                  value: settledCount.toString(),
+                  color: AppColors.neonGreen,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _miniStatusRow(
+                  context: context,
+                  label: 'Rejected',
+                  value: rejectedCount.toString(),
+                  color: AppColors.neonRed,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _miniStatusRow({
+    required BuildContext context,
+    required String label,
+    required String value,
+    required Color color,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bgColor = isDark
+        ? AppColors.nightSurfaceElevated
+        : Theme.of(
+            context,
+          ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.75);
+    final labelColor = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.58 : 0.72);
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: TextStyle(color: labelColor, fontSize: 10)),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: TextStyle(
+              color: color,
+              fontSize: 15,
+              fontWeight: FontWeight.w900,
             ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _claimStatPill({
+    required BuildContext context,
+    required String label,
+    required String value,
+    required IconData icon,
+    required Color color,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bgColor = isDark
+        ? AppColors.nightSurface
+        : Theme.of(context).colorScheme.surface;
+    final valueColor = Theme.of(context).colorScheme.onSurface;
+    final labelColor = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.65 : 0.74);
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: color.withValues(alpha: 0.18)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 17, color: color),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            style: TextStyle(
+              color: valueColor,
+              fontSize: 18,
+              fontWeight: FontWeight.w900,
+              letterSpacing: -0.2,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(label, style: TextStyle(color: labelColor, fontSize: 10)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyClaimsState(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bgColor = isDark
+        ? AppColors.nightSurface
+        : Theme.of(context).colorScheme.surface;
+    final borderColor = isDark
+        ? AppColors.nightBorder
+        : Theme.of(context).colorScheme.outline.withValues(alpha: 0.28);
+    final primaryText = Theme.of(context).colorScheme.onSurface;
+    final secondaryText = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.62 : 0.74);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: borderColor),
+      ),
+      child: Column(
+        children: [
+          Icon(
+            Icons.receipt_long_outlined,
+            size: 38,
+            color: secondaryText.withValues(alpha: 0.78),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            'No claims in this category',
+            style: TextStyle(
+              color: primaryText,
+              fontSize: 15,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Your claim activity will appear here once a threshold is crossed.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: secondaryText, fontSize: 12, height: 1.35),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildClaimsHelpCard(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bgColor = isDark
+        ? AppColors.nightSurface
+        : Theme.of(context).colorScheme.surface;
+    final borderColor = isDark
+        ? AppColors.nightBorder
+        : Theme.of(context).colorScheme.outline.withValues(alpha: 0.28);
+    final primaryText = Theme.of(context).colorScheme.onSurface;
+    final secondaryText = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.68 : 0.76);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(color: borderColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Need help with a claim?',
+            style: TextStyle(
+              color: primaryText,
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Our claim specialists are available 24/7 in Kannada, Hindi, and English.',
+            style: TextStyle(color: secondaryText, fontSize: 12, height: 1.35),
+          ),
+          const SizedBox(height: 14),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: _openZoneLockReport,
+                  icon: const Icon(Icons.lock_person_outlined),
+                  label: const Text('Report ZoneLock'),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: ElevatedButton.icon(
+                  onPressed: _showNewClaimSheet,
+                  icon: const Icon(Icons.add_rounded),
+                  label: const Text('New claim'),
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -522,7 +849,11 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
 
   String _userInitials(String? name) {
     final safeName = _coerceString(name);
-    final parts = safeName.trim().split(' ').where((p) => p.isNotEmpty).toList();
+    final parts = safeName
+        .trim()
+        .split(' ')
+        .where((p) => p.isNotEmpty)
+        .toList();
     if (parts.isEmpty) return 'U';
     if (parts.length == 1) return parts.first.substring(0, 1).toUpperCase();
     return '${parts.first[0]}${parts.last[0]}'.toUpperCase();
@@ -538,25 +869,51 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
   }
 
   void _showNotificationsSheet() {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final sheetBg = isDark
+        ? AppColors.nightSurface
+        : Theme.of(context).colorScheme.surface;
+    final primaryText = Theme.of(context).colorScheme.onSurface;
+    final secondaryText = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.7 : 0.8);
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
       builder: (_) {
-        return ListView(
-          shrinkWrap: true,
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
-          children: const [
-            ListTile(
-              leading: Icon(Icons.update_outlined),
-              title: Text('Claim #17210 moved to review'),
-              subtitle: Text('Our team requested one additional proof image'),
-            ),
-            ListTile(
-              leading: Icon(Icons.account_balance_wallet_outlined),
-              title: Text('Settlement complete for #17209'),
-              subtitle: Text('Rs 1,450 transferred to your linked bank'),
-            ),
-          ],
+        return Container(
+          color: sheetBg,
+          child: ListView(
+            shrinkWrap: true,
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
+            children: [
+              ListTile(
+                leading: Icon(Icons.update_outlined, color: primaryText),
+                title: Text(
+                  'Claim #17210 moved to review',
+                  style: TextStyle(color: primaryText),
+                ),
+                subtitle: Text(
+                  'Our team requested one additional proof image',
+                  style: TextStyle(color: secondaryText),
+                ),
+              ),
+              ListTile(
+                leading: Icon(
+                  Icons.account_balance_wallet_outlined,
+                  color: primaryText,
+                ),
+                title: Text(
+                  'Settlement complete for #17209',
+                  style: TextStyle(color: primaryText),
+                ),
+                subtitle: Text(
+                  'Rs 1,450 transferred to your linked bank',
+                  style: TextStyle(color: secondaryText),
+                ),
+              ),
+            ],
+          ),
         );
       },
     );
@@ -579,7 +936,10 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                   backgroundColor: AppColors.primary,
                   child: Text(
                     _userInitials(safeName),
-                    style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
                 ),
                 title: Text(safeName),
@@ -659,7 +1019,10 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                       children: [
                         const Text(
                           'Report a new claim',
-                          style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.w700,
+                          ),
                         ),
                         const SizedBox(height: 12),
                         const Text(
@@ -674,24 +1037,25 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                         Wrap(
                           spacing: 8,
                           runSpacing: 8,
-                          children: [
-                            'TrafficBlock',
-                            'RainLock',
-                            'AQI Guard',
-                            'ZoneLock',
-                            'HeatBlock',
-                          ].map((type) {
-                            final isSelected = selectedType == type;
-                            return ChoiceChip(
-                              label: Text(type),
-                              selected: isSelected,
-                              onSelected: (_) {
-                                setSheetState(() {
-                                  selectedType = type;
-                                });
-                              },
-                            );
-                          }).toList(),
+                          children:
+                              [
+                                'TrafficBlock',
+                                'RainLock',
+                                'AQI Guard',
+                                'ZoneLock',
+                                'HeatBlock',
+                              ].map((type) {
+                                final isSelected = selectedType == type;
+                                return ChoiceChip(
+                                  label: Text(type),
+                                  selected: isSelected,
+                                  onSelected: (_) {
+                                    setSheetState(() {
+                                      selectedType = type;
+                                    });
+                                  },
+                                );
+                              }).toList(),
                         ),
                         const SizedBox(height: 10),
                         TextField(
@@ -709,14 +1073,23 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                             onPressed: () async {
                               final messenger = ScaffoldMessenger.of(context);
                               final navigator = Navigator.of(sheetContext);
-                              final desc = descriptionController.text.trim().isEmpty
+                              final desc =
+                                  descriptionController.text.trim().isEmpty
                                   ? 'No additional details provided'
                                   : descriptionController.text.trim();
                               ClaimType claimType = ClaimType.trafficBlock;
-                              if (selectedType == 'RainLock') claimType = ClaimType.rainLock;
-                              if (selectedType == 'AQI Guard') claimType = ClaimType.aqiGuard;
-                              if (selectedType == 'ZoneLock') claimType = ClaimType.zoneLock;
-                              if (selectedType == 'HeatBlock') claimType = ClaimType.heatBlock;
+                              if (selectedType == 'RainLock') {
+                                claimType = ClaimType.rainLock;
+                              }
+                              if (selectedType == 'AQI Guard') {
+                                claimType = ClaimType.aqiGuard;
+                              }
+                              if (selectedType == 'ZoneLock') {
+                                claimType = ClaimType.zoneLock;
+                              }
+                              if (selectedType == 'HeatBlock') {
+                                claimType = ClaimType.heatBlock;
+                              }
 
                               try {
                                 await _apiService.submitClaim(
@@ -731,7 +1104,9 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                                 if (!context.mounted) return;
                                 messenger.showSnackBar(
                                   const SnackBar(
-                                    content: Text('Claim submission failed. Please try again.'),
+                                    content: Text(
+                                      'Claim submission failed. Please try again.',
+                                    ),
                                   ),
                                 );
                                 return;
@@ -764,10 +1139,27 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
   }
 
   void _showClaimDetails(Claim claim) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final sheetBg = isDark
+        ? AppColors.nightSurface
+        : Theme.of(context).colorScheme.surface;
+    final cardBg = isDark
+        ? AppColors.nightSurfaceElevated
+        : Theme.of(
+            context,
+          ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.75);
+    final borderColor = isDark
+        ? AppColors.nightBorder
+        : Theme.of(context).colorScheme.outline.withValues(alpha: 0.28);
+    final primaryText = Theme.of(context).colorScheme.onSurface;
+    final secondaryText = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.68 : 0.78);
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
       useSafeArea: true,
+      backgroundColor: sheetBg,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
@@ -778,19 +1170,18 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Claim header
               Row(
                 children: [
                   Container(
                     width: 40,
                     height: 40,
                     decoration: BoxDecoration(
-                      color: AppColors.accentLight,
+                      color: claim.statusColor.withValues(alpha: 0.14),
                       borderRadius: BorderRadius.circular(12),
                     ),
-                    child: const Icon(
+                    child: Icon(
                       Icons.receipt_long_outlined,
-                      color: AppColors.primary,
+                      color: claim.statusColor,
                       size: 20,
                     ),
                   ),
@@ -800,44 +1191,44 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                     children: [
                       Text(
                         'Claim ${claim.id}',
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 20,
                           fontWeight: FontWeight.w800,
-                          color: AppColors.textPrimary,
+                          color: primaryText,
                         ),
                       ),
                       Text(
                         '${claim.typeShortName} · ${claim.statusLabel}',
-                        style: const TextStyle(
-                          fontSize: 12,
-                          color: AppColors.textSecondary,
-                        ),
+                        style: TextStyle(fontSize: 12, color: secondaryText),
                       ),
                     ],
                   ),
                 ],
               ),
               const SizedBox(height: 16),
-              // Details row
               Container(
                 padding: const EdgeInsets.all(14),
                 decoration: BoxDecoration(
-                  color: AppColors.surfaceLight,
-                  borderRadius: BorderRadius.circular(14),
+                  color: cardBg,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: borderColor),
                 ),
                 child: Row(
                   children: [
                     _DetailItem(
+                      isDark: isDark,
                       label: 'Amount',
-                      value: 'Rs ${claim.amount.toStringAsFixed(0)}',
+                      value: '₹${claim.amount.toStringAsFixed(0)}',
                     ),
-                    const VerticalDivider(width: 32),
+                    Container(width: 1, height: 32, color: borderColor),
                     _DetailItem(
+                      isDark: isDark,
                       label: 'Status',
                       value: claim.statusLabel,
                     ),
-                    const VerticalDivider(width: 32),
+                    Container(width: 1, height: 32, color: borderColor),
                     _DetailItem(
+                      isDark: isDark,
                       label: 'Type',
                       value: claim.typeShortName,
                     ),
@@ -845,12 +1236,15 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                 ),
               ),
               const SizedBox(height: 14),
-              const Text(
+              Text(
                 'Our reviewer will update this timeline as soon as verification completes.',
-                style: TextStyle(color: AppColors.textSecondary, fontSize: 13),
+                style: TextStyle(
+                  color: secondaryText,
+                  fontSize: 13,
+                  height: 1.35,
+                ),
               ),
               const SizedBox(height: 20),
-              // Escalate button (Issue #9)
               if (claim.status == ClaimStatus.inReview ||
                   claim.status == ClaimStatus.escalated ||
                   claim.status == ClaimStatus.pending)
@@ -859,25 +1253,27 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                   child: OutlinedButton.icon(
                     icon: const Icon(
                       Icons.escalator_warning_rounded,
-                      color: AppColors.error,
+                      color: AppColors.neonAmber,
                       size: 18,
                     ),
                     label: const Text(
                       'Escalate this claim',
                       style: TextStyle(
-                        color: AppColors.error,
+                        color: AppColors.neonAmber,
                         fontWeight: FontWeight.w700,
                       ),
                     ),
                     onPressed: () async {
                       Navigator.of(sheetCtx).pop();
-                      final submitted =
-                          await EscalationSheet.show(context, claim);
+                      final submitted = await EscalationSheet.show(
+                        context,
+                        claim,
+                      );
                       if (submitted == true && mounted) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(
                             content: Text(
-                              'Escalation submitted. A reviewer will contact you within 2 hrs.'
+                              'Escalation submitted. A reviewer will contact you within 2 hrs.',
                             ),
                           ),
                         );
@@ -885,7 +1281,8 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                       }
                     },
                     style: OutlinedButton.styleFrom(
-                      side: const BorderSide(color: AppColors.error),
+                      side: const BorderSide(color: AppColors.neonAmber),
+                      foregroundColor: AppColors.neonAmber,
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(14),
                       ),
@@ -893,6 +1290,28 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
                     ),
                   ),
                 ),
+              if (claim.status == ClaimStatus.settled &&
+                  claim.bankInfo != null) ...[
+                const SizedBox(height: 14),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(14),
+                  decoration: BoxDecoration(
+                    color: AppColors.neonGreen.withValues(alpha: 0.10),
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(
+                      color: AppColors.neonGreen.withValues(alpha: 0.20),
+                    ),
+                  ),
+                  child: Text(
+                    'Settled to ${claim.bankInfo}',
+                    style: TextStyle(
+                      color: primaryText.withValues(alpha: 0.88),
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              ],
             ],
           ),
         );
@@ -902,9 +1321,7 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
 
   Future<void> _openZoneLockReport() async {
     final submitted = await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
-        builder: (_) => const ZoneLockReportScreen(),
-      ),
+      MaterialPageRoute<bool>(builder: (_) => const ZoneLockReportScreen()),
     );
     if (submitted == true && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -915,14 +1332,18 @@ class _ClaimsScreenState extends State<ClaimsScreen> {
       await _loadClaims();
     }
   }
-
 }
 
 // Helper widget for claim detail row items
 class _DetailItem extends StatelessWidget {
-  const _DetailItem({required this.label, required this.value});
+  const _DetailItem({
+    required this.label,
+    required this.value,
+    required this.isDark,
+  });
   final String label;
   final String value;
+  final bool isDark;
 
   @override
   Widget build(BuildContext context) {
@@ -931,19 +1352,19 @@ class _DetailItem extends StatelessWidget {
         children: [
           Text(
             label,
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 11,
-              color: AppColors.textTertiary,
+              color: isDark ? Colors.white70 : AppColors.textSecondary,
               fontWeight: FontWeight.w600,
             ),
           ),
           const SizedBox(height: 2),
           Text(
             value,
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 14,
               fontWeight: FontWeight.w700,
-              color: AppColors.textPrimary,
+              color: isDark ? Colors.white : AppColors.textPrimary,
             ),
           ),
         ],
@@ -953,24 +1374,44 @@ class _DetailItem extends StatelessWidget {
 }
 
 class _ClaimsTopBackgroundPainter extends CustomPainter {
-  const _ClaimsTopBackgroundPainter();
+  const _ClaimsTopBackgroundPainter({required this.isDark});
+
+  final bool isDark;
 
   @override
   void paint(Canvas canvas, Size size) {
     final backgroundPaint = Paint()
-      ..shader = const LinearGradient(
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
-        colors: [
-          Color(0xFFE7F2FF),
-          Color(0xFFF0F8FF),
-          Color(0xFFF8FBFF),
-        ],
-      ).createShader(Rect.fromLTWH(0, 0, size.width, size.height));
+      ..shader =
+          (isDark
+                  ? const LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: [
+                        Color(0xFF07111F),
+                        Color(0xFF0B1728),
+                        Color(0xFF13263A),
+                      ],
+                    )
+                  : const LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: [
+                        Color(0xFFE7F0FF),
+                        Color(0xFFF1F6FF),
+                        Color(0xFFFAFCFF),
+                      ],
+                    ))
+              .createShader(Rect.fromLTWH(0, 0, size.width, size.height));
 
-    canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), backgroundPaint);
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, size.width, size.height),
+      backgroundPaint,
+    );
 
-    final shapePaint = Paint()..color = AppColors.info.withValues(alpha: 0.12);
+    final shapePaint = Paint()
+      ..color = (isDark ? AppColors.neonCyan : AppColors.info).withValues(
+        alpha: isDark ? 0.12 : 0.10,
+      );
     final shapePath = Path()
       ..moveTo(-20, size.height * 0.74)
       ..lineTo(size.width * 0.42, size.height * 0.56)
@@ -983,10 +1424,27 @@ class _ClaimsTopBackgroundPainter extends CustomPainter {
     final ringPaint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.5
-      ..color = AppColors.info.withValues(alpha: 0.15);
+      ..color = AppColors.info.withValues(alpha: isDark ? 0.15 : 0.22);
 
-    canvas.drawCircle(Offset(size.width * 0.18, size.height * 0.2), 32, ringPaint);
-    canvas.drawCircle(Offset(size.width * 0.86, size.height * 0.3), 48, ringPaint);
+    canvas.drawCircle(
+      Offset(size.width * 0.18, size.height * 0.2),
+      32,
+      ringPaint,
+    );
+    canvas.drawCircle(
+      Offset(size.width * 0.86, size.height * 0.3),
+      48,
+      ringPaint,
+    );
+    final glowPaint = Paint()
+      ..color = (isDark ? AppColors.neonGreen : AppColors.success).withValues(
+        alpha: isDark ? 0.08 : 0.10,
+      );
+    canvas.drawCircle(
+      Offset(size.width * 0.82, size.height * 0.18),
+      size.shortestSide * 0.28,
+      glowPaint,
+    );
   }
 
   @override

--- a/lib/screens/coverage/coverage_screen.dart
+++ b/lib/screens/coverage/coverage_screen.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
 import 'package:intl/intl.dart';
+import 'package:showcaseview/showcaseview.dart';
 
 import '../../models/claim_model.dart';
 import '../../models/plan_model.dart';
 import '../../models/user_model.dart';
 import '../../services/api_service.dart';
+import '../../services/guide_preferences.dart';
 import '../../services/policy_document_opener.dart';
 import '../../services/tab_router.dart';
 import '../../theme/app_colors.dart';
@@ -19,32 +22,12 @@ class CoverageScreen extends StatefulWidget {
 class _CoverageScreenState extends State<CoverageScreen> {
   static const String _policyDocumentAssetPath =
       'assets/documents/SaatDin Policy Document.pdf';
-  static const List<InsurancePlan> _defaultPlans = <InsurancePlan>[
-    InsurancePlan(
-      name: 'Starter',
-      weeklyPremium: 45,
-      perTriggerPayout: 280,
-      maxDaysPerWeek: 3,
-    ),
-    InsurancePlan(
-      name: 'Smart',
-      weeklyPremium: 70,
-      perTriggerPayout: 400,
-      maxDaysPerWeek: 4,
-      isPopular: true,
-    ),
-    InsurancePlan(
-      name: 'Pro',
-      weeklyPremium: 95,
-      perTriggerPayout: 520,
-      maxDaysPerWeek: 5,
-    ),
-  ];
 
   final ApiService _apiService = ApiService();
-  List<InsurancePlan> _plans = List<InsurancePlan>.from(_defaultPlans);
+  final GlobalKey _guideTierKey = GlobalKey();
+  List<InsurancePlan> _plans = const <InsurancePlan>[];
   List<Claim> _claims = const <Claim>[];
-  User _user = const User.empty();
+  User? _user;
   String _activePlanName = '';
   int _activeWeeklyPremium = 0;
   int _activePerTriggerPayout = 0;
@@ -52,10 +35,12 @@ class _CoverageScreenState extends State<CoverageScreen> {
   String? _pendingPlanName;
   String? _pendingEffectiveDate;
   String? _tierConsistencyWarning;
-  String? _dataSyncNotice;
   int? _backendCleanStreakWeeks;
   double? _backendLoyaltyDiscountPercent;
   bool _isLoading = true;
+  bool _shouldShowGuide = false;
+  bool _guidePreferenceResolved = false;
+  bool _guideStarted = false;
   int _currentTierIndex = 1;
   int _selectedTierIndex = 1;
   int _simulatorIndex = 1;
@@ -104,6 +89,28 @@ class _CoverageScreenState extends State<CoverageScreen> {
   void initState() {
     super.initState();
     _loadCoverageData();
+    unawaited(_resolveGuidePreference());
+  }
+
+  Future<void> _resolveGuidePreference() async {
+    final shouldShow = await GuidePreferences.shouldShow(
+      GuidePreferences.coverageGuideSeen,
+    );
+    if (!mounted) return;
+    setState(() {
+      _shouldShowGuide = shouldShow;
+      _guidePreferenceResolved = true;
+    });
+  }
+
+  void _maybeStartGuide(BuildContext context) {
+    if (!_guidePreferenceResolved || !_shouldShowGuide || _guideStarted) return;
+    _guideStarted = true;
+    unawaited(GuidePreferences.markSeen(GuidePreferences.coverageGuideSeen));
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ShowCaseWidget.of(context).startShowCase([_guideTierKey]);
+    });
   }
 
   Future<void> _loadCoverageData() async {
@@ -112,55 +119,24 @@ class _CoverageScreenState extends State<CoverageScreen> {
     });
 
     try {
-      var user = _user;
-      var plans = List<InsurancePlan>.from(_plans.isEmpty ? _defaultPlans : _plans);
-      var claims = List<Claim>.from(_claims);
-      var policy = <String, dynamic>{};
-      String? syncNotice;
-
-      try {
-        user = await _apiService.getProfile('me');
-      } catch (error) {
-        syncNotice = _isAuthRelatedError(error)
-            ? 'Live policy data unavailable. Showing standard coverage until you sign in.'
-            : 'Could not refresh live policy data. Showing standard coverage.';
-      }
-
-      try {
-        policy = await _apiService.getPolicy('me');
-      } catch (_) {
-        syncNotice ??= 'Using standard coverage values while live policy sync is unavailable.';
-      }
-
-      final planZone = user.zonePincode.trim().isNotEmpty ? user.zonePincode : user.zone;
-      final planPlatform = user.platform.trim();
-      if (planZone.isNotEmpty && planPlatform.isNotEmpty) {
-        try {
-          final fetchedPlans = await _apiService.getPlans(zone: planZone, platform: planPlatform);
-          if (fetchedPlans.isNotEmpty) {
-            plans = fetchedPlans;
-          }
-        } catch (_) {
-          syncNotice ??= 'Using standard plan tiers while live plans sync is unavailable.';
-        }
-      }
-
-      try {
-        claims = await _apiService.getClaims('me');
-      } catch (_) {
-        // Keep claim history optional so the screen can still render.
-      }
-
-      final activePlanName = _coerceString(
-        policy['plan'],
-        fallback: _coerceString(user.plan, fallback: plans.first.name),
+      final user = await _apiService.getProfile('me');
+      final policy = await _apiService.getPolicy('me');
+      final planZone = user.zonePincode.trim().isNotEmpty
+          ? user.zonePincode
+          : user.zone;
+      final plans = await _apiService.getPlans(
+        zone: planZone,
+        platform: user.platform,
       );
-      final activeWeeklyPremium =
-          (policy['weeklyPremium'] as num?)?.toInt() ?? plans.first.weeklyPremium;
-      final activePerTriggerPayout =
-          (policy['perTriggerPayout'] as num?)?.toInt() ?? plans.first.perTriggerPayout;
-      final activeMaxDaysPerWeek =
-          (policy['maxDaysPerWeek'] as num?)?.toInt() ?? plans.first.maxDaysPerWeek;
+      final claims = await _apiService.getClaims('me');
+
+      final activePlanName = _coerceString(policy['plan'], fallback: user.plan);
+      final activeWeeklyPremium = (policy['weeklyPremium'] as num? ?? 0)
+          .toInt();
+      final activePerTriggerPayout = (policy['perTriggerPayout'] as num? ?? 0)
+          .toInt();
+      final activeMaxDaysPerWeek = (policy['maxDaysPerWeek'] as num? ?? 0)
+          .toInt();
 
       var currentIndex = plans.indexWhere(
         (p) => p.name.toLowerCase() == activePlanName.toLowerCase(),
@@ -168,7 +144,6 @@ class _CoverageScreenState extends State<CoverageScreen> {
       if (currentIndex < 0) {
         currentIndex = 0;
       }
-      final safeCurrentIndex = _clampIndex(currentIndex, plans.length);
 
       final pendingPlanName = _coerceString(policy['pendingPlan']);
       final hasActiveTierMismatch =
@@ -197,13 +172,24 @@ class _CoverageScreenState extends State<CoverageScreen> {
         _pendingPlanName = policy['pendingPlan'] as String?;
         _pendingEffectiveDate = policy['pendingEffectiveDate'] as String?;
         _tierConsistencyWarning = tierConsistencyWarning;
-        _dataSyncNotice = syncNotice;
-        _backendCleanStreakWeeks = (policy['cleanStreakWeeks'] as num?)?.toInt();
-        _backendLoyaltyDiscountPercent = (policy['loyaltyDiscountPercent'] as num?)?.toDouble();
-        _currentTierIndex = safeCurrentIndex;
-        _selectedTierIndex = safeCurrentIndex;
-        _simulatorIndex = safeCurrentIndex;
+        _backendCleanStreakWeeks = (policy['cleanStreakWeeks'] as num?)
+            ?.toInt();
+        _backendLoyaltyDiscountPercent =
+            (policy['loyaltyDiscountPercent'] as num?)?.toDouble();
+        _currentTierIndex = currentIndex;
+        _selectedTierIndex = currentIndex;
+        _simulatorIndex = currentIndex;
       });
+    } catch (error) {
+      if (mounted) {
+        if (!_isAuthRelatedError(error)) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Could not refresh coverage details.'),
+            ),
+          );
+        }
+      }
     } finally {
       if (mounted) {
         setState(() {
@@ -224,434 +210,509 @@ class _CoverageScreenState extends State<CoverageScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final pageBackground = isDark
+        ? AppColors.nightBackground
+        : AppColors.scaffoldBackground;
+
     if (_isLoading) {
-      return const Scaffold(
-        backgroundColor: AppColors.scaffoldBackground,
+      return Scaffold(
+        backgroundColor: pageBackground,
         body: Center(child: CircularProgressIndicator()),
       );
     }
 
     final user = _user;
-    final selectedTierIndex = _clampIndex(_selectedTierIndex, _plans.length);
-    final currentTierIndex = _clampIndex(_currentTierIndex, _plans.length);
-    final simulatorIndex = _clampIndex(_simulatorIndex, _plans.length);
-    final selectedPlan = _plans[selectedTierIndex];
-    final estimatedPremium = _calculateEstimatedPremium();
-
-    return Scaffold(
-      backgroundColor: AppColors.scaffoldBackground,
-      body: Stack(
-        children: [
-          const Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            child: SizedBox(
-              height: 210,
-              child: CustomPaint(
-                painter: _CoverageTopBackgroundPainter(),
-              ),
+    if (user == null || _plans.isEmpty) {
+      return Scaffold(
+        backgroundColor: pageBackground,
+        body: Center(
+          child: Text(
+            'Coverage data unavailable. Please retry.',
+            style: TextStyle(
+              color: isDark ? Colors.white70 : AppColors.textSecondary,
             ),
           ),
-          SafeArea(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _buildTopUtilityButtons(user),
-                  const SizedBox(height: 14),
-                  const Text(
-                    'Coverage',
-                    style: TextStyle(
-                      fontSize: 30,
-                      fontWeight: FontWeight.w800,
-                      color: AppColors.textPrimary,
-                      letterSpacing: -0.4,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  const Text(
-                    'Understand what you pay for and manage policy week to week.',
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: AppColors.textSecondary,
-                    ),
-                  ),
-                  if (_dataSyncNotice != null && _dataSyncNotice!.isNotEmpty) ...[
-                    const SizedBox(height: 12),
-                    _buildDataSyncNotice(_dataSyncNotice!),
-                  ],
-                  const SizedBox(height: 18),
-              const _CoverageSectionHeader('Tier Selector'),
-              const SizedBox(height: 10),
-              if (_tierConsistencyWarning != null && _tierConsistencyWarning!.isNotEmpty)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 10),
-                  child: _buildTierConsistencyWarning(_tierConsistencyWarning!),
-                ),
-              if (_pendingPlanName != null && _pendingPlanName!.isNotEmpty)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 10),
-                  child: _buildPendingPlanNotice(),
-                ),
-              Padding(
-                padding: const EdgeInsets.only(bottom: 10),
-                child: _buildCurrentPlanLimitsCard(),
-              ),
-              ..._plans.asMap().entries.map(
-                (entry) {
-                  final index = entry.key;
-                  final plan = entry.value;
-                  final isCurrent = index == currentTierIndex;
-                  final isSelected = index == selectedTierIndex;
+        ),
+      );
+    }
 
-                  return Padding(
-                    padding: const EdgeInsets.only(bottom: 10),
-                    child: InkWell(
-                      borderRadius: BorderRadius.circular(16),
-                      onTap: () {
-                        setState(() {
-                          _selectedTierIndex = index;
-                          _simulatorIndex = index;
-                        });
-                      },
-                      child: Container(
-                        width: double.infinity,
-                        padding: const EdgeInsets.all(14),
-                        decoration: BoxDecoration(
-                          color: isSelected
-                              ? AppColors.cardSelectedBackground
-                              : AppColors.cardBackground,
-                          borderRadius: BorderRadius.circular(16),
-                          border: Border.all(
-                            color: isSelected
-                                ? AppColors.cardSelectedBorder
-                                : AppColors.border,
-                            width: isSelected ? 1.4 : 1,
+    final selectedPlan = _plans[_selectedTierIndex];
+    final estimatedPremium = _calculateEstimatedPremium();
+
+    return ShowCaseWidget(
+      builder: (guideContext) {
+        _maybeStartGuide(guideContext);
+        return Scaffold(
+          backgroundColor: pageBackground,
+          body: Stack(
+            children: [
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: SizedBox(
+                  height: 210,
+                  child: CustomPaint(
+                    painter: _CoverageTopBackgroundPainter(isDark: isDark),
+                  ),
+                ),
+              ),
+              SafeArea(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _buildTopUtilityButtons(user),
+                      const SizedBox(height: 14),
+                      Text(
+                        'Coverage',
+                        style: TextStyle(
+                          fontSize: 30,
+                          fontWeight: FontWeight.w800,
+                          color: isDark ? Colors.white : AppColors.textPrimary,
+                          letterSpacing: -0.4,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        'Understand what you pay for and manage policy week to week.',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: isDark
+                              ? Colors.white70
+                              : AppColors.textSecondary,
+                        ),
+                      ),
+                      const SizedBox(height: 18),
+                      Showcase(
+                        key: _guideTierKey,
+                        title: 'Tier Selector',
+                        description:
+                            'Compare plans, check current limits, and pick the best tier before requesting changes.',
+                        child: const _CoverageSectionHeader('Tier Selector'),
+                      ),
+                      const SizedBox(height: 10),
+                      if (_tierConsistencyWarning != null &&
+                          _tierConsistencyWarning!.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 10),
+                          child: _buildTierConsistencyWarning(
+                            _tierConsistencyWarning!,
                           ),
                         ),
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
+                      if (_pendingPlanName != null &&
+                          _pendingPlanName!.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 10),
+                          child: _buildPendingPlanNotice(),
+                        ),
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: _buildCurrentPlanLimitsCard(),
+                      ),
+                      ..._plans.asMap().entries.map((entry) {
+                        final index = entry.key;
+                        final plan = entry.value;
+                        final isCurrent = index == _currentTierIndex;
+                        final isSelected = index == _selectedTierIndex;
+
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 10),
+                          child: InkWell(
+                            borderRadius: BorderRadius.circular(16),
+                            onTap: () {
+                              setState(() {
+                                _selectedTierIndex = index;
+                                _simulatorIndex = index;
+                              });
+                            },
+                            child: Container(
+                              width: double.infinity,
+                              padding: const EdgeInsets.all(14),
+                              decoration: BoxDecoration(
+                                color: isSelected
+                                    ? (isDark
+                                          ? AppColors.neonGreen.withValues(
+                                              alpha: 0.12,
+                                            )
+                                          : AppColors.cardSelectedBackground)
+                                    : (isDark
+                                          ? AppColors.nightSurface
+                                          : AppColors.cardBackground),
+                                borderRadius: BorderRadius.circular(16),
+                                border: Border.all(
+                                  color: isSelected
+                                      ? (isDark
+                                            ? AppColors.neonGreen
+                                            : AppColors.cardSelectedBorder)
+                                      : (isDark
+                                            ? AppColors.nightBorder
+                                            : AppColors.border),
+                                  width: isSelected ? 1.4 : 1,
+                                ),
+                              ),
+                              child: Row(
                                 children: [
-                                  Row(
-                                    children: [
-                                      Text(
-                                        plan.name,
-                                        style: const TextStyle(
-                                          fontSize: 17,
-                                          fontWeight: FontWeight.w700,
-                                          color: AppColors.textPrimary,
-                                        ),
-                                      ),
-                                      if (isCurrent) ...[
-                                        const SizedBox(width: 8),
-                                        Container(
-                                          padding: const EdgeInsets.symmetric(
-                                            horizontal: 8,
-                                            vertical: 3,
-                                          ),
-                                          decoration: BoxDecoration(
-                                            color: AppColors.successLight,
-                                            borderRadius: BorderRadius.circular(999),
-                                          ),
-                                          child: const Text(
-                                            'Current',
-                                            style: TextStyle(
-                                              fontSize: 10,
-                                              fontWeight: FontWeight.w700,
-                                              color: AppColors.success,
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Row(
+                                          children: [
+                                            Text(
+                                              plan.name,
+                                              style: TextStyle(
+                                                fontSize: 17,
+                                                fontWeight: FontWeight.w700,
+                                                color: isDark
+                                                    ? Colors.white
+                                                    : AppColors.textPrimary,
+                                              ),
                                             ),
+                                            if (isCurrent) ...[
+                                              const SizedBox(width: 8),
+                                              Container(
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                      horizontal: 8,
+                                                      vertical: 3,
+                                                    ),
+                                                decoration: BoxDecoration(
+                                                  color: AppColors.successLight,
+                                                  borderRadius:
+                                                      BorderRadius.circular(
+                                                        999,
+                                                      ),
+                                                ),
+                                                child: const Text(
+                                                  'Current',
+                                                  style: TextStyle(
+                                                    fontSize: 10,
+                                                    fontWeight: FontWeight.w700,
+                                                    color: AppColors.success,
+                                                  ),
+                                                ),
+                                              ),
+                                            ],
+                                          ],
+                                        ),
+                                        const SizedBox(height: 6),
+                                        Text(
+                                          'Est. weekly premium: Rs ${plan.weeklyPremium}',
+                                          style: TextStyle(
+                                            fontSize: 13,
+                                            color: isDark
+                                                ? Colors.white70
+                                                : AppColors.textSecondary,
+                                          ),
+                                        ),
+                                        const SizedBox(height: 2),
+                                        Text(
+                                          'Per-trigger payout: Rs ${plan.perTriggerPayout}',
+                                          style: TextStyle(
+                                            fontSize: 13,
+                                            color: isDark
+                                                ? Colors.white70
+                                                : AppColors.textSecondary,
                                           ),
                                         ),
                                       ],
-                                    ],
-                                  ),
-                                  const SizedBox(height: 6),
-                                  Text(
-                                    'Est. weekly premium: Rs ${plan.weeklyPremium}',
-                                    style: const TextStyle(
-                                      fontSize: 13,
-                                      color: AppColors.textSecondary,
                                     ),
                                   ),
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    'Per-trigger payout: Rs ${plan.perTriggerPayout}',
-                                    style: const TextStyle(
-                                      fontSize: 13,
-                                      color: AppColors.textSecondary,
-                                    ),
+                                  Icon(
+                                    isSelected
+                                        ? Icons.radio_button_checked
+                                        : Icons.radio_button_off,
+                                    color: isSelected
+                                        ? AppColors.primary
+                                        : AppColors.textTertiary,
                                   ),
                                 ],
                               ),
                             ),
-                            Icon(
-                              isSelected
-                                  ? Icons.radio_button_checked
-                                  : Icons.radio_button_off,
-                              color: isSelected
-                                  ? AppColors.primary
-                                  : AppColors.textTertiary,
+                          ),
+                        );
+                      }),
+                      const SizedBox(height: 2),
+                      SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          onPressed: _selectedTierIndex == _currentTierIndex
+                              ? null
+                              : () async {
+                                  try {
+                                    final policy = await _apiService
+                                        .updatePolicyPlan(selectedPlan.name);
+                                    if (!context.mounted) return;
+                                    final pendingPlan =
+                                        policy['pendingPlan'] as String?;
+                                    final pendingEffectiveDate =
+                                        policy['pendingEffectiveDate']
+                                            as String?;
+                                    setState(() {
+                                      _pendingPlanName = pendingPlan;
+                                      _pendingEffectiveDate =
+                                          pendingEffectiveDate;
+                                    });
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        content: Text(
+                                          pendingEffectiveDate == null
+                                              ? '${selectedPlan.name} plan will apply next week.'
+                                              : '${selectedPlan.name} plan will apply from $pendingEffectiveDate.',
+                                        ),
+                                      ),
+                                    );
+                                  } catch (_) {
+                                    if (!context.mounted) return;
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'Policy update failed. Please verify login and retry.',
+                                        ),
+                                      ),
+                                    );
+                                  }
+                                },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: AppColors.primary,
+                            foregroundColor: Colors.white,
+                            disabledBackgroundColor: AppColors.border,
+                            disabledForegroundColor: AppColors.textSecondary,
+                            padding: const EdgeInsets.symmetric(vertical: 14),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                          ),
+                          child: Text(
+                            _selectedTierIndex == _currentTierIndex
+                                ? 'Current tier active'
+                                : 'Switch to ${selectedPlan.name}',
+                            style: const TextStyle(fontWeight: FontWeight.w700),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      const _CoverageSectionHeader('Premium Breakdown'),
+                      const SizedBox(height: 10),
+                      _buildCard(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            _breakdownRow('Base', 'Rs 45.00'),
+                            const SizedBox(height: 8),
+                            _breakdownRow(
+                              'Zone risk (Bellandur 1.3x)',
+                              'x 1.30',
+                            ),
+                            const SizedBox(height: 8),
+                            _breakdownRow('Platform (Blinkit 1.1x)', 'x 1.10'),
+                            const SizedBox(height: 8),
+                            _breakdownRow(
+                              'Loyalty discount (${_loyaltyDiscountPercent.toStringAsFixed(0)}%)',
+                              '- ${_loyaltyDiscountPercent.toStringAsFixed(0)}%',
+                            ),
+                            const Padding(
+                              padding: EdgeInsets.symmetric(vertical: 10),
+                              child: Divider(
+                                height: 1,
+                                color: AppColors.border,
+                              ),
+                            ),
+                            _breakdownRow(
+                              'Estimated weekly premium',
+                              'Rs ${_currencyFormat.format(estimatedPremium)}',
+                              emphasize: true,
                             ),
                           ],
                         ),
                       ),
-                    ),
-                  );
-                },
-              ),
-              const SizedBox(height: 2),
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: selectedTierIndex == currentTierIndex
-                      ? null
-                      : () async {
-                          try {
-                            final policy = await _apiService.updatePolicyPlan(selectedPlan.name);
-                            if (!context.mounted) return;
-                            final pendingPlan = policy['pendingPlan'] as String?;
-                            final pendingEffectiveDate = policy['pendingEffectiveDate'] as String?;
-                            setState(() {
-                              _pendingPlanName = pendingPlan;
-                              _pendingEffectiveDate = pendingEffectiveDate;
-                            });
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text(
-                                  pendingEffectiveDate == null
-                                      ? '${selectedPlan.name} plan will start with the next weekly cycle.'
-                                      : '${selectedPlan.name} plan starts on $pendingEffectiveDate.',
+                      const SizedBox(height: 20),
+                      const _CoverageSectionHeader('Trigger Explainer'),
+                      const SizedBox(height: 10),
+                      _buildCard(
+                        child: Column(
+                          children: _triggers
+                              .map(
+                                (trigger) => Theme(
+                                  data: Theme.of(
+                                    context,
+                                  ).copyWith(dividerColor: Colors.transparent),
+                                  child: ExpansionTile(
+                                    tilePadding: EdgeInsets.zero,
+                                    childrenPadding: const EdgeInsets.only(
+                                      bottom: 12,
+                                    ),
+                                    title: Text(
+                                      trigger.title,
+                                      style: const TextStyle(
+                                        fontSize: 15,
+                                        fontWeight: FontWeight.w700,
+                                        color: AppColors.textPrimary,
+                                      ),
+                                    ),
+                                    children: [
+                                      _triggerDetail('Cause', trigger.cause),
+                                      const SizedBox(height: 6),
+                                      _triggerDetail(
+                                        'Threshold',
+                                        trigger.threshold,
+                                      ),
+                                      const SizedBox(height: 6),
+                                      _triggerDetail(
+                                        'Payout',
+                                        'Rs ${_currencyFormat.format(trigger.payout)}',
+                                      ),
+                                      const SizedBox(height: 6),
+                                      _triggerDetail(
+                                        'Last triggered in your zone',
+                                        '${trigger.lastTriggered}, Rs ${_currencyFormat.format(trigger.payout)} paid',
+                                        accent: true,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+                      _buildCard(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              'For complete terms and conditions, please refer to the policy document.',
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: AppColors.textSecondary,
+                                height: 1.4,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            TextButton.icon(
+                              onPressed: _openPolicyDocument,
+                              icon: const Icon(
+                                Icons.picture_as_pdf_outlined,
+                                size: 18,
+                              ),
+                              label: const Text('View policy document'),
+                              style: TextButton.styleFrom(
+                                foregroundColor: AppColors.primary,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 0,
+                                  vertical: 4,
                                 ),
                               ),
-                            );
-                          } catch (_) {
-                            if (!context.mounted) return;
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('Policy update failed. Please verify login and retry.'),
-                              ),
-                            );
-                          }
-                        },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColors.primary,
-                    foregroundColor: Colors.white,
-                    disabledBackgroundColor: AppColors.border,
-                    disabledForegroundColor: AppColors.textSecondary,
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
-                    ),
-                  ),
-                  child: Text(
-                    selectedTierIndex == currentTierIndex
-                        ? 'Current tier active'
-                        : 'Switch to ${selectedPlan.name}',
-                    style: const TextStyle(fontWeight: FontWeight.w700),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 20),
-              const _CoverageSectionHeader('Premium Breakdown'),
-              const SizedBox(height: 10),
-              _buildCard(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _breakdownRow('Base', 'Rs 45.00'),
-                    const SizedBox(height: 8),
-                    _breakdownRow('Zone risk (Bellandur 1.3x)', 'x 1.30'),
-                    const SizedBox(height: 8),
-                    _breakdownRow('Platform (Blinkit 1.1x)', 'x 1.10'),
-                    const SizedBox(height: 8),
-                    _breakdownRow(
-                      'Loyalty discount (${_loyaltyDiscountPercent.toStringAsFixed(0)}%)',
-                      '- ${_loyaltyDiscountPercent.toStringAsFixed(0)}%',
-                    ),
-                    const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 10),
-                      child: Divider(height: 1, color: AppColors.border),
-                    ),
-                    _breakdownRow(
-                      'Estimated weekly premium',
-                      'Rs ${_currencyFormat.format(estimatedPremium)}',
-                      emphasize: true,
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 20),
-              const _CoverageSectionHeader('Trigger Explainer'),
-              const SizedBox(height: 10),
-              _buildCard(
-                child: Column(
-                  children: _triggers
-                      .map(
-                        (trigger) => Theme(
-                          data: Theme.of(context).copyWith(
-                            dividerColor: Colors.transparent,
-                          ),
-                          child: ExpansionTile(
-                            tilePadding: EdgeInsets.zero,
-                            childrenPadding: const EdgeInsets.only(bottom: 12),
-                            title: Text(
-                              trigger.title,
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      const _CoverageSectionHeader('Loyalty Tracker'),
+                      const SizedBox(height: 10),
+                      _buildCard(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              _loyaltyHeadline,
                               style: const TextStyle(
-                                fontSize: 15,
+                                fontSize: 14,
                                 fontWeight: FontWeight.w700,
                                 color: AppColors.textPrimary,
                               ),
                             ),
-                            children: [
-                              _triggerDetail('Cause', trigger.cause),
-                              const SizedBox(height: 6),
-                              _triggerDetail('Threshold', trigger.threshold),
-                              const SizedBox(height: 6),
-                              _triggerDetail(
-                                'Payout',
-                                'Rs ${_currencyFormat.format(trigger.payout)}',
+                            const SizedBox(height: 8),
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(999),
+                              child: LinearProgressIndicator(
+                                minHeight: 8,
+                                value: _loyaltyProgress,
+                                backgroundColor: AppColors.borderLight,
+                                valueColor: const AlwaysStoppedAnimation<Color>(
+                                  AppColors.primary,
+                                ),
                               ),
-                              const SizedBox(height: 6),
-                              _triggerDetail(
-                                'Last triggered in your zone',
-                                '${trigger.lastTriggered}, Rs ${_currencyFormat.format(trigger.payout)} paid',
-                                accent: true,
-                              ),
-                            ],
-                          ),
-                        ),
-                      )
-                      .toList(),
-                ),
-              ),
-              const SizedBox(height: 10),
-              _buildCard(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Text(
-                      'For complete terms and conditions, please refer to the policy document.',
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: AppColors.textSecondary,
-                        height: 1.4,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TextButton.icon(
-                      onPressed: _openPolicyDocument,
-                      icon: const Icon(Icons.picture_as_pdf_outlined, size: 18),
-                      label: const Text('View policy document'),
-                      style: TextButton.styleFrom(
-                        foregroundColor: AppColors.primary,
-                        padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 20),
-              const _CoverageSectionHeader('Loyalty Tracker'),
-              const SizedBox(height: 10),
-              _buildCard(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      _loyaltyHeadline,
-                      style: const TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w700,
-                        color: AppColors.textPrimary,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(999),
-                      child: LinearProgressIndicator(
-                        minHeight: 8,
-                        value: _loyaltyProgress,
-                        backgroundColor: AppColors.borderLight,
-                        valueColor:
-                            const AlwaysStoppedAnimation<Color>(AppColors.primary),
-                      ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      _loyaltySubtext,
-                      style: const TextStyle(
-                        fontSize: 12,
-                        color: AppColors.textSecondary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 20),
-              const _CoverageSectionHeader('What-if Simulator'),
-              const SizedBox(height: 10),
-              _buildCard(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Selected tier: ${_plans[simulatorIndex].name}',
-                      style: const TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w700,
-                        color: AppColors.textPrimary,
-                      ),
-                    ),
-                    Slider(
-                      value: simulatorIndex.toDouble(),
-                      min: 0,
-                      max: (_plans.length - 1).toDouble(),
-                      divisions: _plans.length > 1 ? _plans.length - 1 : null,
-                      label: _plans[simulatorIndex].name,
-                      activeColor: AppColors.primary,
-                      onChanged: (value) {
-                        setState(() {
-                          _simulatorIndex = value.round();
-                        });
-                      },
-                    ),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: _plans
-                          .map(
-                            (plan) => Text(
-                              plan.name,
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              _loyaltySubtext,
                               style: const TextStyle(
                                 fontSize: 12,
                                 color: AppColors.textSecondary,
                               ),
                             ),
-                          )
-                          .toList(),
-                    ),
-                    const SizedBox(height: 12),
-                    Text(
-                      'If you had been on ${_plans[simulatorIndex].name} last month, your estimated payout would have been Rs ${_currencyFormat.format(_simulatedPayout(simulatorIndex))}.',
-                      style: const TextStyle(
-                        fontSize: 13,
-                        color: AppColors.textPrimary,
-                        height: 1.4,
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                      const SizedBox(height: 20),
+                      const _CoverageSectionHeader('What-if Simulator'),
+                      const SizedBox(height: 10),
+                      _buildCard(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Selected tier: ${_plans[_simulatorIndex].name}',
+                              style: const TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w700,
+                                color: AppColors.textPrimary,
+                              ),
+                            ),
+                            Slider(
+                              value: _simulatorIndex.toDouble(),
+                              min: 0,
+                              max: (_plans.length - 1).toDouble(),
+                              divisions: _plans.length > 1
+                                  ? _plans.length - 1
+                                  : null,
+                              label: _plans[_simulatorIndex].name,
+                              activeColor: AppColors.primary,
+                              onChanged: (value) {
+                                setState(() {
+                                  _simulatorIndex = value.round();
+                                });
+                              },
+                            ),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: _plans
+                                  .map(
+                                    (plan) => Text(
+                                      plan.name,
+                                      style: const TextStyle(
+                                        fontSize: 12,
+                                        color: AppColors.textSecondary,
+                                      ),
+                                    ),
+                                  )
+                                  .toList(),
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              'If you had been on ${_plans[_simulatorIndex].name} last month, your estimated payout would have been Rs ${_currencyFormat.format(_simulatedPayout(_simulatorIndex))}.',
+                              style: const TextStyle(
+                                fontSize: 13,
+                                color: AppColors.textPrimary,
+                                height: 1.4,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-                ],
-              ),
-            ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 
@@ -753,46 +814,7 @@ class _CoverageScreenState extends State<CoverageScreen> {
 
   double _calculateEstimatedPremium() {
     if (_plans.isEmpty) return 0;
-    final safeIndex = _clampIndex(_selectedTierIndex, _plans.length);
-    return _plans[safeIndex].weeklyPremium.toDouble();
-  }
-
-  int _clampIndex(int index, int length) {
-    if (length <= 0) return 0;
-    return index.clamp(0, length - 1).toInt();
-  }
-
-  Widget _buildDataSyncNotice(String message) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      decoration: BoxDecoration(
-        color: AppColors.infoLight,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: AppColors.info.withValues(alpha: 0.28)),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Padding(
-            padding: EdgeInsets.only(top: 1),
-            child: Icon(Icons.info_outline, color: AppColors.info, size: 16),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              message,
-              style: const TextStyle(
-                fontSize: 12,
-                color: AppColors.textPrimary,
-                fontWeight: FontWeight.w600,
-                height: 1.35,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
+    return _plans[_selectedTierIndex].weeklyPremium.toDouble();
   }
 
   int _simulatedPayout(int tierIndex) {
@@ -809,10 +831,14 @@ class _CoverageScreenState extends State<CoverageScreen> {
   }
 
   Widget _buildPendingPlanNotice() {
+    final theme = Theme.of(context);
+    final primaryText = theme.colorScheme.onSurface;
     final safePendingDate = _coerceString(_pendingEffectiveDate);
     final effectiveText = safePendingDate.isEmpty
         ? 'next week'
-        : DateFormat('d MMM').format(DateTime.tryParse(safePendingDate) ?? DateTime.now());
+        : DateFormat(
+            'd MMM',
+          ).format(DateTime.tryParse(safePendingDate) ?? DateTime.now());
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
@@ -823,9 +849,9 @@ class _CoverageScreenState extends State<CoverageScreen> {
       ),
       child: Text(
         'Pending change: $_pendingPlanName will become active on $effectiveText. Your current week coverage stays unchanged.',
-        style: const TextStyle(
+        style: TextStyle(
           fontSize: 12,
-          color: AppColors.textPrimary,
+          color: primaryText,
           fontWeight: FontWeight.w600,
           height: 1.35,
         ),
@@ -834,6 +860,8 @@ class _CoverageScreenState extends State<CoverageScreen> {
   }
 
   Widget _buildTierConsistencyWarning(String message) {
+    final theme = Theme.of(context);
+    final primaryText = theme.colorScheme.onSurface;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
@@ -847,15 +875,19 @@ class _CoverageScreenState extends State<CoverageScreen> {
         children: [
           const Padding(
             padding: EdgeInsets.only(top: 1),
-            child: Icon(Icons.warning_amber_rounded, color: AppColors.error, size: 16),
+            child: Icon(
+              Icons.warning_amber_rounded,
+              color: AppColors.error,
+              size: 16,
+            ),
           ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               message,
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 12,
-                color: AppColors.textPrimary,
+                color: primaryText,
                 fontWeight: FontWeight.w600,
                 height: 1.35,
               ),
@@ -867,32 +899,44 @@ class _CoverageScreenState extends State<CoverageScreen> {
   }
 
   Widget _buildCurrentPlanLimitsCard() {
-    final activeName = _activePlanName.isEmpty ? 'Current plan' : _activePlanName;
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.70 : 0.78,
+    );
+    final activeName = _activePlanName.isEmpty
+        ? 'Current plan'
+        : _activePlanName;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
-        color: AppColors.infoLight,
+        color: isDark
+            ? AppColors.info.withValues(alpha: 0.16)
+            : AppColors.infoLight,
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: AppColors.info.withValues(alpha: 0.28)),
+        border: Border.all(
+          color: AppColors.info.withValues(alpha: isDark ? 0.42 : 0.28),
+        ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
             '$activeName limits active this week',
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 12,
-              color: AppColors.textPrimary,
+              color: primaryText,
               fontWeight: FontWeight.w700,
             ),
           ),
           const SizedBox(height: 5),
           Text(
             'Premium: Rs $_activeWeeklyPremium · Per trigger: Rs $_activePerTriggerPayout · Max days/week: $_activeMaxDaysPerWeek',
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 12,
-              color: AppColors.textSecondary,
+              color: secondaryText,
               fontWeight: FontWeight.w600,
             ),
           ),
@@ -924,7 +968,9 @@ class _CoverageScreenState extends State<CoverageScreen> {
 
     var streak = 0;
     for (var weekOffset = 0; weekOffset < 12; weekOffset++) {
-      final weekStart = today.subtract(Duration(days: today.weekday - 1 + (weekOffset * 7)));
+      final weekStart = today.subtract(
+        Duration(days: today.weekday - 1 + (weekOffset * 7)),
+      );
       final weekEnd = weekStart.add(const Duration(days: 7));
       final hasClaimThisWeek = claimDates.any(
         (date) => !date.isBefore(weekStart) && date.isBefore(weekEnd),
@@ -986,7 +1032,11 @@ class _CoverageScreenState extends State<CoverageScreen> {
 
   String _userInitials(String? name) {
     final safeName = _coerceString(name);
-    final parts = safeName.trim().split(' ').where((p) => p.isNotEmpty).toList();
+    final parts = safeName
+        .trim()
+        .split(' ')
+        .where((p) => p.isNotEmpty)
+        .toList();
     if (parts.isEmpty) return 'U';
     if (parts.length == 1) return parts.first.substring(0, 1).toUpperCase();
     return '${parts.first[0]}${parts.last[0]}'.toUpperCase();
@@ -1043,7 +1093,10 @@ class _CoverageScreenState extends State<CoverageScreen> {
                   backgroundColor: AppColors.primary,
                   child: Text(
                     _userInitials(safeName),
-                    style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
                 ),
                 title: Text(safeName),
@@ -1093,19 +1146,23 @@ class _CoverageScreenState extends State<CoverageScreen> {
   }
 
   Widget _buildCard({required Widget child}) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: AppColors.cardBackground,
+        color: isDark ? AppColors.nightSurface : AppColors.cardBackground,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: AppColors.border),
+        border: Border.all(
+          color: isDark ? AppColors.nightBorder : AppColors.border,
+        ),
       ),
       child: child,
     );
   }
 
   Widget _breakdownRow(String label, String value, {bool emphasize = false}) {
+    final primaryText = Theme.of(context).colorScheme.onSurface;
     return Row(
       children: [
         Expanded(
@@ -1114,7 +1171,7 @@ class _CoverageScreenState extends State<CoverageScreen> {
             style: TextStyle(
               fontSize: 13,
               fontWeight: emphasize ? FontWeight.w700 : FontWeight.w500,
-              color: AppColors.textPrimary,
+              color: primaryText,
             ),
           ),
         ),
@@ -1123,7 +1180,7 @@ class _CoverageScreenState extends State<CoverageScreen> {
           style: TextStyle(
             fontSize: 13,
             fontWeight: emphasize ? FontWeight.w800 : FontWeight.w600,
-            color: AppColors.textPrimary,
+            color: primaryText,
           ),
         ),
       ],
@@ -1131,6 +1188,11 @@ class _CoverageScreenState extends State<CoverageScreen> {
   }
 
   Widget _triggerDetail(String label, String value, {bool accent = false}) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final primaryText = Theme.of(context).colorScheme.onSurface;
+    final secondaryText = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.72 : 0.80);
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1138,10 +1200,7 @@ class _CoverageScreenState extends State<CoverageScreen> {
           width: 130,
           child: Text(
             '$label:',
-            style: const TextStyle(
-              fontSize: 12,
-              color: AppColors.textSecondary,
-            ),
+            style: TextStyle(fontSize: 12, color: secondaryText),
           ),
         ),
         Expanded(
@@ -1149,7 +1208,7 @@ class _CoverageScreenState extends State<CoverageScreen> {
             value,
             style: TextStyle(
               fontSize: 12,
-              color: accent ? AppColors.primary : AppColors.textPrimary,
+              color: accent ? AppColors.primary : primaryText,
               fontWeight: accent ? FontWeight.w600 : FontWeight.w500,
             ),
           ),
@@ -1166,12 +1225,13 @@ class _CoverageSectionHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final primaryText = Theme.of(context).colorScheme.onSurface;
     return Text(
       title,
-      style: const TextStyle(
+      style: TextStyle(
         fontSize: 16,
         fontWeight: FontWeight.w700,
-        color: AppColors.textPrimary,
+        color: primaryText,
       ),
     );
   }
@@ -1194,19 +1254,27 @@ class _TriggerInfo {
 }
 
 class _CoverageTopBackgroundPainter extends CustomPainter {
-  const _CoverageTopBackgroundPainter();
+  const _CoverageTopBackgroundPainter({required this.isDark});
+
+  final bool isDark;
 
   @override
   void paint(Canvas canvas, Size size) {
     final base = Paint()
-      ..shader = const LinearGradient(
+      ..shader = LinearGradient(
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
-        colors: [
-          AppColors.accentLight,
-          Color(0xFFD7F3EF),
-          Color(0xFFF4FBF9),
-        ],
+        colors: isDark
+            ? <Color>[
+                AppColors.nightSurface,
+                AppColors.nightSurfaceElevated,
+                AppColors.nightBackground,
+              ]
+            : <Color>[
+                AppColors.accentLight,
+                const Color(0xFFD7F3EF),
+                const Color(0xFFF4FBF9),
+              ],
       ).createShader(Rect.fromLTWH(0, 0, size.width, size.height));
 
     final basePath = Path()
@@ -1221,7 +1289,9 @@ class _CoverageTopBackgroundPainter extends CustomPainter {
     canvas.drawPath(basePath, base);
 
     final stripePaint = Paint()
-      ..color = AppColors.primary.withValues(alpha: 0.08)
+      ..color = (isDark ? AppColors.neonCyan : AppColors.primary).withValues(
+        alpha: 0.10,
+      )
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.2;
 
@@ -1236,10 +1306,25 @@ class _CoverageTopBackgroundPainter extends CustomPainter {
       stripePaint,
     );
 
-    final dotPaint = Paint()..color = AppColors.accent.withValues(alpha: 0.18);
-    canvas.drawCircle(Offset(size.width * 0.15, size.height * 0.12), 12, dotPaint);
-    canvas.drawCircle(Offset(size.width * 0.82, size.height * 0.2), 20, dotPaint);
-    canvas.drawCircle(Offset(size.width * 0.58, size.height * 0.72), 10, dotPaint);
+    final dotPaint = Paint()
+      ..color = (isDark ? AppColors.neonPurple : AppColors.accent).withValues(
+        alpha: 0.18,
+      );
+    canvas.drawCircle(
+      Offset(size.width * 0.15, size.height * 0.12),
+      12,
+      dotPaint,
+    );
+    canvas.drawCircle(
+      Offset(size.width * 0.82, size.height * 0.2),
+      20,
+      dotPaint,
+    );
+    canvas.drawCircle(
+      Offset(size.width * 0.58, size.height * 0.72),
+      10,
+      dotPaint,
+    );
   }
 
   @override

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,24 +1,94 @@
+import 'dart:math' as math;
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
-import '../../theme/app_colors.dart';
-import '../../models/user_model.dart';
+import 'package:showcaseview/showcaseview.dart';
+
 import '../../models/claim_model.dart';
 import '../../models/plan_model.dart';
-import '../../routes/app_routes.dart';
+import '../../models/user_model.dart';
+import '../../models/zone_risk_model.dart';
 import '../../services/api_service.dart';
+import '../../services/guide_preferences.dart';
 import '../../services/tab_router.dart';
-import 'policy_status_screen.dart';
+import '../../services/zone_risk_service.dart';
+import '../../theme/app_colors.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
-  static final ApiService _apiService = ApiService();
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
 
-  Future<_HomeViewData> _loadHomeViewData() async {
+class _HomeScreenState extends State<HomeScreen> {
+  final ApiService _apiService = ApiService();
+  final ZoneRiskService _zoneRiskService = ZoneRiskService();
+  final NumberFormat _currency = NumberFormat.currency(
+    locale: 'en_IN',
+    symbol: '₹',
+    decimalDigits: 0,
+  );
+  final DateFormat _timeFormat = DateFormat('ha');
+
+  final GlobalKey _tourStatusKey = GlobalKey();
+  final GlobalKey _tourForecastKey = GlobalKey();
+  final GlobalKey _tourActionsKey = GlobalKey();
+
+  late Future<_DashboardData> _dashboardFuture;
+  bool _shouldShowTour = false;
+  bool _tourPreferenceResolved = false;
+  bool _tourStarted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _dashboardFuture = _loadDashboard();
+    unawaited(_resolveTourPreference());
+  }
+
+  Future<void> _resolveTourPreference() async {
+    final shouldShow = await GuidePreferences.shouldShow(
+      GuidePreferences.homeGuideSeen,
+    );
+    if (!mounted) return;
+    setState(() {
+      _shouldShowTour = shouldShow;
+      _tourPreferenceResolved = true;
+    });
+  }
+
+  Future<void> _markTourSeen() async {
+    await GuidePreferences.markSeen(GuidePreferences.homeGuideSeen);
+  }
+
+  void _maybeStartTour(BuildContext context) {
+    if (!_tourPreferenceResolved || !_shouldShowTour || _tourStarted) return;
+    _tourStarted = true;
+    unawaited(_markTourSeen());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ShowCaseWidget.of(
+        context,
+      ).startShowCase([_tourStatusKey, _tourForecastKey, _tourActionsKey]);
+    });
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _dashboardFuture = _loadDashboard();
+    });
+    await _dashboardFuture;
+  }
+
+  Future<_DashboardData> _loadDashboard() async {
     User user = const User.empty();
     Map<String, dynamic> policy = <String, dynamic>{};
+    Map<String, dynamic> payoutDashboard = <String, dynamic>{};
+    Map<String, dynamic> activeTriggers = <String, dynamic>{};
     List<Claim> claims = const <Claim>[];
+    ZoneRisk? zoneRisk;
 
     try {
       user = await _apiService.getProfile('me');
@@ -38,1308 +108,672 @@ class HomeScreen extends StatelessWidget {
       claims = const <Claim>[];
     }
 
-    final latestClaim = _latestClaimForUpdates(claims);
-    final perTriggerPayout = (policy['perTriggerPayout'] as num? ?? 0).toDouble();
-    final zoneKey = (policy['zonePincode'] as String? ?? user.zonePincode).trim();
-    final policyZone = _coerceText(policy['zone'], fallback: user.zone);
-    final policyPlatform = _coerceText(policy['platform'], fallback: user.platform);
+    try {
+      payoutDashboard = await _apiService.getPayoutDashboard();
+    } catch (_) {
+      payoutDashboard = <String, dynamic>{};
+    }
 
-    final maxDaysPerWeek = (policy['maxDaysPerWeek'] as num? ?? 0).toInt();
-    final nextBillingDate = _coerceDateString(
-      policy['nextBillingDate'],
-      fallback: _fallbackNextBillingDateString(),
+    final zoneKey = _coerceString(
+      user.zonePincode,
+      fallback: _coerceString(policy['zonePincode']),
     );
-    final cycleStartDate = _coerceDateString(
-      policy['cycleStartDate'],
-      fallback: _shiftDateString(nextBillingDate, days: -7),
-    );
-    final cycleEndDate = _coerceDateString(
-      policy['cycleEndDate'],
-      fallback: nextBillingDate,
-    );
-    final backendStatus = _coerceText(policy['status'], fallback: '').toLowerCase();
-    final pendingEffectiveDate = _coerceText(policy['pendingEffectiveDate']);
-    final policyStatus = _coerceText(policy['status'], fallback: 'inactive').toLowerCase();
-    final inferredScheduled = pendingEffectiveDate.isNotEmpty &&
-      DateTime.tryParse(pendingEffectiveDate)?.toUtc().isAfter(DateTime.now().toUtc()) == true;
-    final isScheduled = backendStatus.isEmpty
-      ? inferredScheduled
-      : backendStatus != 'active';
-    final daysLeft = (policy['daysLeft'] as num?)?.toInt();
-    final amountPaidThisWeek = (policy['amountPaidThisWeek'] as num?)?.toDouble();
-
-    final claimsThisWeek = claims.where((claim) {
-      return claim.status == ClaimStatus.settled;
-    }).toList();
-
-    final claimsProcessedThisWeek = claimsThisWeek.length;
-    final payoutThisWeek = claimsThisWeek
-        .where((claim) => claim.status == ClaimStatus.settled)
-        .fold<double>(0, (sum, claim) => sum + claim.amount);
-    final settledAutoTriggersThisWeek = claimsThisWeek
-        .where((claim) => claim.status == ClaimStatus.settled)
-        .toList()
-      ..sort((left, right) => right.date.compareTo(left.date));
-    final autoTriggerMessages = <String>[];
-
-    if (claims.isNotEmpty) {
+    if (zoneKey.isNotEmpty) {
       try {
-        final activeTrigger = await _apiService.getActiveTriggers(
-          zoneKey.isNotEmpty ? zoneKey : user.zone,
-        );
-        if (activeTrigger['hasActiveAlert'] == true) {
-          autoTriggerMessages.add(
-            _buildLiveTriggerImpactMessage(activeTrigger, perTriggerPayout),
-          );
-        }
+        zoneRisk = await _zoneRiskService.getByPincode(zoneKey);
       } catch (_) {
-        // Fall back to claims-based updates if trigger endpoint fails.
+        zoneRisk = null;
       }
     }
 
-    if (settledAutoTriggersThisWeek.isNotEmpty) {
-      autoTriggerMessages.add(
-        _buildTriggerImpactMessage(settledAutoTriggersThisWeek.first),
-      );
+    final zoneLabel = _zoneLabel(user, policy, zoneKey);
+    if (zoneLabel.isNotEmpty) {
+      try {
+        activeTriggers = await _apiService.getActiveTriggers(zoneLabel);
+      } catch (_) {
+        activeTriggers = <String, dynamic>{};
+      }
     }
 
-    final coveredDaysLeft = daysLeft ?? (maxDaysPerWeek - claimsProcessedThisWeek).clamp(0, maxDaysPerWeek);
-
-    final activePlan = InsurancePlan(
-      name: (policy['plan'] as String? ?? user.plan).trim(),
-      weeklyPremium: (amountPaidThisWeek ?? (policy['weeklyPremium'] as num? ?? 0).toDouble()).toInt(),
-      perTriggerPayout: (policy['perTriggerPayout'] as num? ?? 0).toInt(),
-      maxDaysPerWeek: (policy['maxDaysPerWeek'] as num? ?? 0).toInt(),
+    final plan = InsurancePlan(
+      name: _coerceString(
+        policy['plan'],
+        fallback: user.plan.isEmpty ? 'Standard' : user.plan,
+      ),
+      weeklyPremium: _coerceInt(policy['weeklyPremium'], fallback: 35),
+      perTriggerPayout: _coerceInt(policy['perTriggerPayout'], fallback: 250),
+      maxDaysPerWeek: _coerceInt(policy['maxDaysPerWeek'], fallback: 6),
       isPopular: false,
     );
 
-    return _HomeViewData(
+    final metrics = _buildMetrics(policy, zoneRisk, activeTriggers);
+    final heroMetric = metrics.reduce(
+      (left, right) => left.ratio >= right.ratio ? left : right,
+    );
+    final status = _deriveStatus(activeTriggers, metrics, claims);
+    final latestSettled = _latestClaim(claims, ClaimStatus.settled);
+    final latestProcessing =
+        _latestClaim(claims, ClaimStatus.inReview) ??
+        _latestClaim(claims, ClaimStatus.escalated);
+    final latestRelevant =
+        latestProcessing ?? latestSettled ?? _latestClaim(claims, null);
+    final nearMiss = _buildNearMissSignal(metrics, activeTriggers);
+    final payoutVault = _buildPayoutVault(payoutDashboard, claims, plan);
+
+    return _DashboardData(
       user: user,
+      plan: plan,
+      policy: policy,
+      payoutDashboard: payoutDashboard,
+      activeTriggers: activeTriggers,
       claims: claims,
-      latestClaim: latestClaim,
-      autoTriggerMessages: autoTriggerMessages,
-      activePlan: activePlan,
-      earningsProtected: (policy['earningsProtected'] as num? ?? 0).toDouble(),
-      totalEarnings: user.totalEarnings > 0
-          ? user.totalEarnings
-          : claims
-              .where((claim) => claim.status == ClaimStatus.settled)
-              .fold<double>(0, (sum, claim) => sum + claim.amount),
-      coveredDaysLeft: coveredDaysLeft,
-      cycleStartDate: cycleStartDate,
-      cycleEndDate: cycleEndDate,
-      pendingEffectiveDate: pendingEffectiveDate,
-      isScheduled: isScheduled,
-      policyStatus: policyStatus,
-      zoneLabel: policyZone,
-      platformLabel: policyPlatform,
-      claimsProcessedThisWeek: claimsProcessedThisWeek,
-      payoutThisWeek: payoutThisWeek,
+      zoneRisk: zoneRisk,
+      metrics: metrics,
+      forecast: _buildForecast(zoneRisk, status),
+      status: status,
+      heroMetric: heroMetric,
+      latestClaim: latestRelevant,
+      latestSettledClaim: latestSettled,
+      upiId: _extractUpiId(payoutDashboard),
+      safetyBanner: _buildSafetyBanner(zoneRisk, activeTriggers),
+      safetyDetail: _buildSafetyDetail(zoneRisk, activeTriggers, zoneLabel),
+      premiumBreakdown: _buildPremiumBreakdown(zoneRisk),
+      nearMiss: nearMiss,
+      payoutVault: payoutVault,
     );
   }
 
-  Claim? _latestClaimForUpdates(List<Claim> claims) {
-    final nonReviewClaims = claims
-        .where((claim) => claim.status != ClaimStatus.inReview)
-        .toList()
-      ..sort((left, right) => right.date.compareTo(left.date));
-
-    if (nonReviewClaims.isNotEmpty) {
-      return nonReviewClaims.first;
-    }
-
-    final allClaims = claims.toList()
-      ..sort((left, right) => right.date.compareTo(left.date));
-    return allClaims.isNotEmpty ? allClaims.first : null;
-  }
-
-  String _buildTriggerImpactMessage(Claim claim) {
-    final amount = NumberFormat('#,##0').format(claim.amount);
-    switch (claim.type) {
-      case ClaimType.rainLock:
-        return 'Congratulations! Your rain cover has been settled. Hurray, ₹$amount has been credited to your account.';
-      case ClaimType.trafficBlock:
-        return 'Congratulations! Your traffic cover has been settled. Hurray, ₹$amount has been credited to your account.';
-      case ClaimType.zoneLock:
-        return 'Congratulations! Your zone lock cover has been settled. Hurray, ₹$amount has been credited to your account.';
-      case ClaimType.aqiGuard:
-        return 'Congratulations! Your AQI cover has been settled. Hurray, ₹$amount has been credited to your account.';
-      case ClaimType.heatBlock:
-        return 'Congratulations! Your heat cover has been settled. Hurray, ₹$amount has been credited to your account.';
-    }
-  }
-
-  String _buildLiveTriggerImpactMessage(
-    Map<String, dynamic> trigger,
-    double perTriggerPayout,
+  _NearMissSignal _buildNearMissSignal(
+    List<_RiskMetric> metrics,
+    Map<String, dynamic> activeTriggers,
   ) {
-    final triggerType = (trigger['alertType'] as String? ?? 'none').toLowerCase();
-    final amount = NumberFormat('#,##0').format(perTriggerPayout);
+    final sorted = metrics.toList()
+      ..sort((left, right) => right.ratio.compareTo(left.ratio));
+    final nearMiss = sorted.firstWhere(
+      (metric) => metric.ratio < 1,
+      orElse: () => sorted.first,
+    );
 
-    switch (triggerType) {
-      case 'rain':
-        return 'Hurray! Rain has been noticed in your area today. Your cover is active, and ₹$amount will be settled into your account.';
-      case 'traffic':
-        return 'Hurray! Traffic has picked up in your area today. Your cover is active, and ₹$amount will be settled into your account.';
-      case 'zonelock':
-        return 'Hurray! A zone lock is active in your area today. Your cover is active, and ₹$amount will be settled into your account.';
-      case 'aqi':
-        return 'Hurray! The air quality in your area needs attention today. Your cover is active, and ₹$amount will be settled into your account.';
-      case 'heat':
-        return 'Hurray! It is a very hot day in your area. Your cover is active, and ₹$amount will be settled into your account.';
-      default:
-        return 'Hurray! We noticed something in your area today. Your cover is active, and it will be settled into your account.';
-    }
-  }
+    final fallbackMinutes = nearMiss.ratio >= 0.9 ? 12 : 24;
+    final monitoringMinutes = _coerceInt(
+      activeTriggers['monitoringWindowMins'],
+      fallback: fallbackMinutes,
+    );
 
-  // Returns the icon and background colour for a trigger message based on its type.
-  // ignore: unused_element
-  ({IconData icon, Color background, Color iconColor}) _triggerIconData(String message) {
-    final lower = message.toLowerCase();
-    if (lower.contains('rain')) {
-      return (
-        icon: Icons.water_drop_outlined,
-        background: const Color(0xFFE6F1FB),
-        iconColor: const Color(0xFF185FA5),
-      );
-    } else if (lower.contains('traffic')) {
-      return (
-        icon: Icons.traffic_outlined,
-        background: const Color(0xFFFAEEDA),
-        iconColor: const Color(0xFFBA7517),
-      );
-    } else if (lower.contains('zone')) {
-      return (
-        icon: Icons.location_off_outlined,
-        background: const Color(0xFFFBEAF0),
-        iconColor: const Color(0xFF993556),
-      );
-    } else if (lower.contains('aqi') || lower.contains('air')) {
-      return (
-        icon: Icons.air_outlined,
-        background: const Color(0xFFEAF3DE),
-        iconColor: const Color(0xFF3B6D11),
-      );
-    } else if (lower.contains('heat') || lower.contains('hot')) {
-      return (
-        icon: Icons.thermostat_outlined,
-        background: const Color(0xFFFCEBEB),
-        iconColor: const Color(0xFFA32D2D),
-      );
-    }
-    return (
-      icon: Icons.bolt_rounded,
-      background: const Color(0xFFE1F5EE),
-      iconColor: AppColors.primary,
+    return _NearMissSignal(
+      metric: nearMiss,
+      monitoringMinutes: monitoringMinutes,
     );
   }
 
-  // Returns a short human-readable title for a trigger message.
-  // ignore: unused_element
-  String _triggerTitle(String message) {
-    final lower = message.toLowerCase();
-    if (lower.contains('rain')) return 'Rain payout incoming';
-    if (lower.contains('traffic')) return 'Traffic payout incoming';
-    if (lower.contains('zone')) return 'Zone lock payout incoming';
-    if (lower.contains('aqi') || lower.contains('air')) return 'AQI payout incoming';
-    if (lower.contains('heat') || lower.contains('hot')) return 'Heat payout incoming';
-    return 'Payout incoming';
+  _PayoutVault _buildPayoutVault(
+    Map<String, dynamic> payoutDashboard,
+    List<Claim> claims,
+    InsurancePlan plan,
+  ) {
+    final settledAmount = claims
+        .where((claim) => claim.status == ClaimStatus.settled)
+        .fold<double>(0, (sum, claim) => sum + claim.amount);
+    final securedAmount = _coerceDouble(
+      payoutDashboard['securedAmount'],
+      fallback: settledAmount,
+    );
+
+    final pendingAmount = _coerceDouble(
+      payoutDashboard['potentialAmount'],
+      fallback: (plan.perTriggerPayout * 2).toDouble(),
+    );
+
+    final total = securedAmount + pendingAmount;
+    final securedRatio = total <= 0
+        ? 0.0
+        : (securedAmount / total).clamp(0.0, 1.0);
+
+    return _PayoutVault(
+      securedAmount: securedAmount,
+      potentialAmount: pendingAmount,
+      securedRatio: securedRatio,
+    );
   }
 
-  // ignore: unused_element
-  InlineSpan _buildAmountHighlightedSpan(String message, TextStyle baseStyle) {
-    final amountPattern = RegExp(r'₹[\d,]+(?:\.\d+)?');
-    final match = amountPattern.firstMatch(message);
+  _ClaimSnapshot? _latestClaim(List<Claim> claims, ClaimStatus? status) {
+    final filtered = status == null
+        ? claims.toList()
+        : claims.where((claim) => claim.status == status).toList();
+    if (filtered.isEmpty) return null;
+    filtered.sort((left, right) => right.date.compareTo(left.date));
+    return _ClaimSnapshot.fromClaim(filtered.first);
+  }
 
-    if (match == null) {
-      return TextSpan(text: message, style: baseStyle);
-    }
+  List<_RiskMetric> _buildMetrics(
+    Map<String, dynamic> policy,
+    ZoneRisk? zoneRisk,
+    Map<String, dynamic> activeTriggers,
+  ) {
+    final activeType = _coerceString(activeTriggers['alertType']).toLowerCase();
+    final rainThreshold =
+        (zoneRisk?.customRainLockThresholdMm3hr ??
+                _coerceInt(policy['rainThresholdMm'], fallback: 50))
+            .toDouble();
+    final aqiThreshold = _coerceDouble(policy['aqiThreshold'], fallback: 400);
+    final heatThreshold = _coerceDouble(policy['heatThresholdC'], fallback: 40);
+    final trafficThreshold = _coerceDouble(
+      policy['trafficThreshold'],
+      fallback: 70,
+    );
 
-    return TextSpan(
-      style: baseStyle,
-      children: [
-        if (match.start > 0) TextSpan(text: message.substring(0, match.start)),
-        TextSpan(
-          text: match.group(0),
-          style: baseStyle.copyWith(
-            fontWeight: FontWeight.w700,
-            color: AppColors.primary,
-          ),
+    final rainCurrent = _metricCurrent(
+      activeTriggers,
+      const ['rainMm', 'rainfallMm', 'currentRainMm', 'reading'],
+      fallback:
+          rainThreshold * (0.35 + ((zoneRisk?.floodRiskScore ?? 35) / 200)),
+    );
+    final aqiCurrent = _metricCurrent(activeTriggers, const [
+      'aqi',
+      'currentAqi',
+      'airQuality',
+      'reading',
+    ], fallback: 180 + ((zoneRisk?.aqiRiskScore ?? 35) * 1.8));
+    final heatCurrent = _metricCurrent(activeTriggers, const [
+      'heat',
+      'temperature',
+      'currentHeatC',
+      'reading',
+    ], fallback: 32 + ((zoneRisk?.compositeRiskScore ?? 42) / 20));
+    final trafficCurrent = _metricCurrent(activeTriggers, const [
+      'traffic',
+      'trafficScore',
+      'currentTraffic',
+      'reading',
+    ], fallback: 28 + ((zoneRisk?.trafficCongestionScore ?? 40) * 0.8));
+
+    return <_RiskMetric>[
+      _RiskMetric(
+        key: 'rain',
+        label: 'Rain',
+        icon: Icons.water_drop_rounded,
+        current: rainCurrent,
+        threshold: rainThreshold,
+        unit: 'mm',
+        detail:
+            'Policy threshold: ${_metricLabel(rainThreshold, 'mm')} crossed at the rain-lock layer.',
+        state: _metricState('rain', activeType, rainCurrent, rainThreshold),
+      ),
+      _RiskMetric(
+        key: 'aqi',
+        label: 'AQI',
+        icon: Icons.air_rounded,
+        current: aqiCurrent,
+        threshold: aqiThreshold,
+        unit: 'AQI',
+        detail:
+            'Policy threshold: ${_metricLabel(aqiThreshold, 'AQI')} for hazardous air.',
+        state: _metricState('aqi', activeType, aqiCurrent, aqiThreshold),
+      ),
+      _RiskMetric(
+        key: 'heat',
+        label: 'Heat',
+        icon: Icons.thermostat_rounded,
+        current: heatCurrent,
+        threshold: heatThreshold,
+        unit: '°C',
+        detail:
+            'Policy threshold: ${_metricLabel(heatThreshold, '°C')} for extreme heat.',
+        state: _metricState('heat', activeType, heatCurrent, heatThreshold),
+      ),
+      _RiskMetric(
+        key: 'traffic',
+        label: 'Traffic',
+        icon: Icons.traffic_rounded,
+        current: trafficCurrent,
+        threshold: trafficThreshold,
+        unit: 'score',
+        detail:
+            'Policy threshold: ${_metricLabel(trafficThreshold, 'score')} for traffic lock.',
+        state: _metricState(
+          'traffic',
+          activeType,
+          trafficCurrent,
+          trafficThreshold,
         ),
-        if (match.end < message.length) TextSpan(text: message.substring(match.end)),
-      ],
+      ),
+    ];
+  }
+
+  List<_ForecastBlock> _buildForecast(ZoneRisk? zoneRisk, _RiskStatus status) {
+    final composite = (zoneRisk?.compositeRiskScore ?? 45)
+        .clamp(0, 100)
+        .toDouble();
+    final baseColor = switch (status.level) {
+      _RiskLevel.safe => AppColors.neonGreen,
+      _RiskLevel.watch => AppColors.neonAmber,
+      _RiskLevel.alert => AppColors.neonRed,
+      _RiskLevel.critical => AppColors.neonPurple,
+    };
+
+    return List<_ForecastBlock>.generate(12, (index) {
+      final hour = DateTime.now().add(Duration(hours: index + 1));
+      final intensity = (composite + (index * 4)).clamp(10, 100).toDouble();
+      final severity = intensity > 80
+          ? _RiskLevel.critical
+          : intensity > 62
+          ? _RiskLevel.alert
+          : intensity > 42
+          ? _RiskLevel.watch
+          : _RiskLevel.safe;
+      final color = switch (severity) {
+        _RiskLevel.safe => AppColors.neonGreen.withValues(alpha: 0.35),
+        _RiskLevel.watch => AppColors.neonAmber.withValues(alpha: 0.50),
+        _RiskLevel.alert => AppColors.neonRed.withValues(alpha: 0.50),
+        _RiskLevel.critical => AppColors.neonPurple.withValues(alpha: 0.60),
+      };
+      return _ForecastBlock(
+        label: _timeFormat
+            .format(hour)
+            .replaceAll('AM', 'A')
+            .replaceAll('PM', 'P'),
+        color: color,
+        caption: severity.label,
+        shimmer: baseColor,
+      );
+    });
+  }
+
+  _RiskStatus _deriveStatus(
+    Map<String, dynamic> activeTriggers,
+    List<_RiskMetric> metrics,
+    List<Claim> claims,
+  ) {
+    if (_latestClaim(claims, ClaimStatus.inReview) != null ||
+        _latestClaim(claims, ClaimStatus.escalated) != null) {
+      return const _RiskStatus(
+        level: _RiskLevel.critical,
+        label: 'Payout paused for review',
+        summary:
+            'Verification is active. Funds are protected until the check clears.',
+      );
+    }
+
+    final activeType = _coerceString(activeTriggers['alertType']).toLowerCase();
+    final hasActiveAlert =
+        activeTriggers['hasActiveAlert'] == true || activeType.isNotEmpty;
+    if (hasActiveAlert) {
+      final breached = metrics
+          .where(
+            (metric) =>
+                metric.state == _RiskMetricState.critical ||
+                metric.state == _RiskMetricState.alert,
+          )
+          .toList();
+      if (breached.isNotEmpty) {
+        final topMetric = breached.reduce(
+          (left, right) => left.ratio >= right.ratio ? left : right,
+        );
+        return _RiskStatus(
+          level: topMetric.state == _RiskMetricState.critical
+              ? _RiskLevel.critical
+              : _RiskLevel.alert,
+          label: '${topMetric.label} threshold crossed',
+          summary:
+              'A live reading is at or above the trigger. Receipt flow is ready.',
+        );
+      }
+      return const _RiskStatus(
+        level: _RiskLevel.alert,
+        label: 'Conditions building fast',
+        summary: 'One or more readings are approaching the payout line.',
+      );
+    }
+
+    final topMetric = metrics.reduce(
+      (left, right) => left.ratio >= right.ratio ? left : right,
+    );
+    if (topMetric.ratio >= 0.8) {
+      return _RiskStatus(
+        level: _RiskLevel.alert,
+        label: '${topMetric.label} near trigger',
+        summary:
+            'The nearest signal is close enough to matter. Keep it on screen.',
+      );
+    }
+    if (topMetric.ratio >= 0.65) {
+      return const _RiskStatus(
+        level: _RiskLevel.watch,
+        label: 'Conditions rising',
+        summary: 'The shift forecaster says keep scanning. No trigger yet.',
+      );
+    }
+    return const _RiskStatus(
+      level: _RiskLevel.safe,
+      label: 'ZONE SAFE',
+      summary: 'No live trigger crossed. The co-pilot is still watching.',
     );
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<_HomeViewData>(
-      future: _loadHomeViewData(),
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Scaffold(
-            backgroundColor: AppColors.scaffoldBackground,
-            body: Center(child: CircularProgressIndicator()),
-          );
-        }
-
-        if (snapshot.hasError || snapshot.data == null) {
-          return const Scaffold(
-            backgroundColor: AppColors.scaffoldBackground,
-            body: Center(
-              child: Text(
-                'Failed to load home data. Please retry.',
-                style: TextStyle(color: AppColors.textSecondary),
-              ),
-            ),
-          );
-        }
-
-        return _buildWithData(context, snapshot.data!);
-      },
-    );
+  List<_AllocationSlice> _buildPremiumBreakdown(ZoneRisk? zoneRisk) {
+    final riskBoost = (zoneRisk?.compositeRiskScore ?? 50) / 100;
+    final rain = (40 + (riskBoost * 12)).round().clamp(34, 52);
+    final heat = (30 + (riskBoost * 4)).round().clamp(24, 36);
+    final traffic = 100 - rain - heat;
+    return [
+      _AllocationSlice(label: 'Rain', share: rain, color: AppColors.neonCyan),
+      _AllocationSlice(label: 'Heat', share: heat, color: AppColors.neonAmber),
+      _AllocationSlice(
+        label: 'Traffic',
+        share: traffic,
+        color: AppColors.neonPurple,
+      ),
+    ];
   }
 
-  Widget _buildWithData(BuildContext context, _HomeViewData data) {
-    final user = data.user;
-    final activePlan = data.activePlan;
+  String _buildSafetyBanner(
+    ZoneRisk? zoneRisk,
+    Map<String, dynamic> activeTriggers,
+  ) {
+    final activeType = _coerceString(activeTriggers['alertType']).toLowerCase();
+    if (activeType.contains('rain')) {
+      return 'Rain is the closest trigger. Keep waterproof gear ready and stay in the thumb zone.';
+    }
+    if (activeType.contains('aqi') || activeType.contains('air')) {
+      return 'AQI is elevated. An N95 mask is strongly recommended before the next batch of orders.';
+    }
+    if (activeType.contains('heat')) {
+      return 'Heat is climbing. Plan a shade break and keep water visible.';
+    }
+    if (zoneRisk != null && zoneRisk.compositeRiskScore >= 75) {
+      return 'Zone risk is high today. Expect rough patches and plan your route around them.';
+    }
+    return 'No severe warning right now. The app is still monitoring your shift windows.';
+  }
 
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      body: SafeArea(
-        top: false,
-        child: Stack(
-          children: [
-            const Positioned(
-              top: 0,
-              left: 0,
-              right: 0,
-              child: SizedBox(
-                height: 210,
-                child: CustomPaint(
-                  painter: _HomeTopBackgroundPainter(topHeight: 210),
-                ),
-              ),
-            ),
-            SingleChildScrollView(
-              padding: const EdgeInsets.fromLTRB(20, 48, 20, 28),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+  String _buildSafetyDetail(
+    ZoneRisk? zoneRisk,
+    Map<String, dynamic> activeTriggers,
+    String zoneLabel,
+  ) {
+    final intensity = zoneRisk?.riskTier ?? 'MEDIUM';
+    final nextCheck = _coerceString(activeTriggers['nextCheckAt']);
+    final label = zoneLabel.isEmpty ? 'your zone' : zoneLabel;
+    return 'Coverage is being checked against $label. Risk tier: $intensity${nextCheck.isNotEmpty ? ' · next check $nextCheck' : ''}.';
+  }
+
+  String _extractUpiId(Map<String, dynamic> payoutDashboard) {
+    final primary = _coerceString(payoutDashboard['primaryUpi']);
+    if (primary.isNotEmpty) return primary;
+    final backup = _coerceString(payoutDashboard['backupUpi']);
+    if (backup.isNotEmpty) return backup;
+    return 'UPI not configured';
+  }
+
+  Widget _buildBody(BuildContext context, _DashboardData data) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final pageBackground = isDark
+        ? AppColors.nightBackground
+        : AppColors.scaffoldBackground;
+    final surfaceColor = isDark
+        ? AppColors.nightSurface
+        : AppColors.cardBackground;
+    final elevatedSurface = isDark
+        ? AppColors.nightSurfaceElevated
+        : AppColors.surfaceLight;
+    final borderColor = isDark ? AppColors.nightBorder : AppColors.border;
+    final primaryText = isDark ? Colors.white : AppColors.textPrimary;
+    final secondaryText = isDark ? Colors.white70 : AppColors.textSecondary;
+
+    final settledClaim = data.latestSettledClaim;
+    final receiptAmount =
+        settledClaim?.amount ??
+        _coerceDouble(
+          data.payoutDashboard['lastPayoutAmount'],
+          fallback: data.plan.perTriggerPayout.toDouble(),
+        );
+    final receiptId =
+        settledClaim?.id ??
+        _coerceString(
+          data.payoutDashboard['lastReferenceId'],
+          fallback: '#READY',
+        );
+
+    return ShowCaseWidget(
+      builder: (tourContext) {
+        _maybeStartTour(tourContext);
+        return Scaffold(
+          backgroundColor: pageBackground,
+          body: SafeArea(
+            bottom: false,
+            child: RefreshIndicator(
+              color: AppColors.neonGreen,
+              backgroundColor: elevatedSurface,
+              onRefresh: _refresh,
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 28),
                 children: [
-                  _buildTopHeader(context, user, data.autoTriggerMessages),
-                  const SizedBox(height: 14),
-                  Container(
-                    width: double.infinity,
-                    height: 1,
-                    color: AppColors.border,
+                  _buildHeader(
+                    data,
+                    elevatedSurface: elevatedSurface,
+                    borderColor: borderColor,
+                    primaryText: primaryText,
+                    secondaryText: secondaryText,
                   ),
                   const SizedBox(height: 16),
-                  _buildPolicyOverviewCard(
-                    context,
-                    user,
-                    activePlan,
-                    data.cycleStartDate,
-                    data.cycleEndDate,
-                    isScheduled: data.isScheduled,
-                    zoneLabel: data.zoneLabel,
-                    platformLabel: data.platformLabel,
+                  Showcase(
+                    key: _tourStatusKey,
+                    title: 'Live Shift Status',
+                    description:
+                        'This banner tells you if your current zone is safe, near trigger, or already crossed.',
+                    child: _buildStatusBanner(
+                      data.status,
+                      primaryText: primaryText,
+                      secondaryText: secondaryText,
+                    ),
                   ),
-                  if (data.policyStatus == 'inactive') ...[
-                    const SizedBox(height: 10),
-                    _buildPaymentDuePrompt(context),
-                  ],
                   const SizedBox(height: 14),
-                  _buildTodaysUpdatesSnapshot(data.latestClaim),
-                  const SizedBox(height: 24),
-                  const Text(
-                    'Quick access',
-                    style: TextStyle(
-                      fontSize: 24,
-                      fontWeight: FontWeight.w800,
-                      color: AppColors.textPrimary,
-                      letterSpacing: -0.4,
-                    ),
+                  _RiskHexagonCard(
+                    title: data.status.label,
+                    summary: data.status.summary,
+                    metricLabel: data.heroMetric?.label ?? 'Signal',
+                    metricValue: data.heroMetric?.displayValue ?? '--',
+                    metricUnit: data.heroMetric?.unit ?? '',
+                    color: data.status.color,
+                    onTap: () =>
+                        _showMetricSheet(context, data.heroMetric, data.status),
                   ),
-                  const SizedBox(height: 10),
-                  _buildQuickActions(context),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  // ignore: unused_element
-  Widget _buildFixedTopLayer(
-    BuildContext context,
-    User user,
-    InsurancePlan activePlan,
-    String cycleStartDate,
-    String cycleEndDate,
-    {
-    required bool isScheduled,
-  }
-  ) {
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 14, 20, 0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildTopHeader(context, user, const <String>[]),
-            const SizedBox(height: 16),
-            _buildPolicyOverviewCard(
-              context,
-              user,
-              activePlan,
-              cycleStartDate,
-              cycleEndDate,
-              isScheduled: isScheduled,
-              zoneLabel: _coerceText(user.zone),
-              platformLabel: _coerceText(user.platform),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  // ignore: unused_element
-  Widget _buildScrollableLowerLayer(
-    BuildContext context,
-    double scrollStart,
-    User user,
-    List<Claim> claims,
-    List<String> autoTriggerMessages,
-    NumberFormat currencyFormat,
-    DateFormat dateFormat,
-    InsurancePlan activePlan,
-    double earningsProtected,
-    double? totalEarnings,
-    int coveredDaysLeft,
-    int claimsProcessedThisWeek,
-    double payoutThisWeek,
-  ) {
-    return Positioned.fill(
-      top: scrollStart,
-      child: Container(
-        decoration: const BoxDecoration(
-          color: AppColors.scaffoldBackground,
-          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-        ),
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.fromLTRB(20, 32, 20, 28),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-                _buildTodaysUpdatesSnapshot(_latestClaimForUpdates(claims)),
-              const SizedBox(height: 18),
-              _buildMetricsRow(
-                user,
-                currencyFormat,
-                earningsProtected: earningsProtected,
-                totalEarnings: totalEarnings,
-              ),
-              const SizedBox(height: 18),
-              _buildSectionHeader('Quick access'),
-              const SizedBox(height: 10),
-              _buildQuickActions(context),
-              const SizedBox(height: 18),
-              _buildSectionHeader('This Week'),
-              const SizedBox(height: 10),
-              _buildWeeklySnapshot(
-                currencyFormat,
-                coveredDaysLeft: coveredDaysLeft,
-                claimsProcessedThisWeek: claimsProcessedThisWeek,
-                payoutThisWeek: payoutThisWeek,
-              ),
-              const SizedBox(height: 18),
-              _buildSectionHeader(
-                'Recent Claims',
-                actionText: 'View all',
-                onTap: () {
-                  _openClaims(context);
-                },
-              ),
-              const SizedBox(height: 10),
-              _buildRecentClaims(claims, currencyFormat, dateFormat),
-              const SizedBox(height: 18),
-              _buildSectionHeader('Next Billing'),
-              const SizedBox(height: 10),
-              _buildNextBillingCard(context, activePlan),
-              const SizedBox(height: 16),
-              _buildPrimaryActions(context),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  // ─── Top header ───────────────────────────────────────────────────────────
-
-  Widget _buildTopHeader(
-    BuildContext context,
-    User user,
-    List<String> recentTriggers,
-  ) {
-    final firstName =
-        user.name.trim().isEmpty ? 'Rider' : user.name.split(' ').first;
-    final initials = _userInitials(user.name);
-    final hasNotifications = recentTriggers.isNotEmpty;
-
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        // Avatar with initials – tapping opens account menu.
-        GestureDetector(
-          onTap: () => _showAccountQuickMenu(context),
-          child: Container(
-            width: 40,
-            height: 40,
-            decoration: BoxDecoration(
-              color: AppColors.primary,
-              shape: BoxShape.circle,
-            ),
-            child: Center(
-              child: Text(
-                initials,
-                style: const TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w700,
-                  color: Colors.white,
-                  letterSpacing: 0.4,
-                ),
-              ),
-            ),
-          ),
-        ),
-        const SizedBox(width: 12),
-        // Two-line greeting.
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                _greetingLabel(),
-                style: const TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.textSecondary,
-                  letterSpacing: 0.5,
-                ),
-              ),
-              const SizedBox(height: 1),
-              Text(
-                'Hi, $firstName 👋',
-                style: const TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.w900,
-                  color: AppColors.textPrimary,
-                  letterSpacing: -0.4,
-                  height: 1.1,
-                ),
-              ),
-            ],
-          ),
-        ),
-        // Bell icon with optional notification dot.
-        GestureDetector(
-          onTap: () => _showRecentTriggersSheet(context, recentTriggers),
-          child: Container(
-            width: 40,
-            height: 40,
-            decoration: BoxDecoration(
-              color: Colors.white,
-              shape: BoxShape.circle,
-              border: Border.all(color: AppColors.border),
-            ),
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                const Icon(
-                  Icons.notifications_none_rounded,
-                  size: 20,
-                  color: AppColors.textPrimary,
-                ),
-                if (hasNotifications)
-                  Positioned(
-                    top: 9,
-                    right: 9,
-                    child: Container(
-                      width: 7,
-                      height: 7,
-                      decoration: BoxDecoration(
-                        color: const Color(0xFFE24B4A),
-                        shape: BoxShape.circle,
-                        border: Border.all(color: Colors.white, width: 1.5),
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  String _userInitials(String name) {
-    final parts = name.trim().split(' ').where((p) => p.isNotEmpty).toList();
-    if (parts.isEmpty) return '?';
-    if (parts.length == 1) return parts.first.substring(0, 1).toUpperCase();
-    return '${parts.first[0]}${parts.last[0]}'.toUpperCase();
-  }
-
-  String _greetingLabel() {
-    final hour = DateTime.now().hour;
-    if (hour < 12) return 'Good morning';
-    if (hour < 17) return 'Good afternoon';
-    return 'Good evening';
-  }
-
-  void _showAccountQuickMenu(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      builder: (sheetContext) {
-        return SafeArea(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ListTile(
-                leading: const Icon(Icons.settings_outlined),
-                title: const Text('Settings'),
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _openProfile(context);
-                },
-              ),
-              ListTile(
-                leading: const Icon(Icons.logout),
-                title: const Text('Logout'),
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  Navigator.pushNamedAndRemoveUntil(
+                  const SizedBox(height: 14),
+                  _buildTriggerPills(
                     context,
-                    AppRoutes.welcome,
-                    (route) => false,
-                  );
-                },
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
-  void _showRecentTriggersSheet(BuildContext context, List<String> recentTriggers) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      builder: (sheetContext) {
-        return ListView(
-          shrinkWrap: true,
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
-          children: [
-            const Text(
-              'Recent triggers',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
-            ),
-            const SizedBox(height: 10),
-            if (recentTriggers.isEmpty)
-              const ListTile(
-                contentPadding: EdgeInsets.zero,
-                leading: Icon(Icons.info_outline),
-                title: Text('No trigger alerts yet'),
-                subtitle: Text('You will see new trigger events here.'),
-              )
-            else
-              ...recentTriggers.map(
-                (trigger) => ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  leading:
-                      const Icon(Icons.bolt_rounded, color: AppColors.primary),
-                  title: Text(trigger),
-                ),
-              ),
-          ],
-        );
-      },
-    );
-  }
-
-  // ─── Policy overview card ─────────────────────────────────────────────────
-
-  Widget _buildPolicyOverviewCard(
-    BuildContext context,
-    User user,
-    InsurancePlan activePlan,
-    String cycleStartDate,
-    String cycleEndDate,
-    {
-    required bool isScheduled,
-    required String zoneLabel,
-    required String platformLabel,
-  }
-  ) {
-    final startLabel = _formatDateLabel(cycleStartDate);
-    final endLabel = _formatDateLabel(cycleEndDate);
-    final planTitle =
-        activePlan.name.trim().isEmpty ? 'Standard' : activePlan.name.trim();
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.fromLTRB(20, 18, 20, 18),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(20),
-        gradient: const LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [
-            Color(0xFF14B890),
-            Color(0xFF109072),
-            Color(0xFF0F7E66),
-          ],
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Status badge – active when live, scheduled when the next cycle is pending.
-          Align(
-            alignment: Alignment.centerRight,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.18),
-                borderRadius: BorderRadius.circular(999),
-                border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.32),
-                ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Container(
-                    width: 6,
-                    height: 6,
-                    decoration: BoxDecoration(
-                      color: isScheduled ? AppColors.error : const Color(0xFF6EFFC2),
-                      shape: BoxShape.circle,
+                    data.metrics,
+                    surfaceColor: surfaceColor,
+                    primaryText: primaryText,
+                    secondaryText: secondaryText,
+                  ),
+                  const SizedBox(height: 16),
+                  _buildNearMissCard(
+                    context,
+                    data.nearMiss,
+                    surfaceColor: surfaceColor,
+                    elevatedSurface: elevatedSurface,
+                    primaryText: primaryText,
+                    secondaryText: secondaryText,
+                  ),
+                  const SizedBox(height: 16),
+                  Showcase(
+                    key: _tourForecastKey,
+                    title: '12-Hour Forecaster',
+                    description:
+                        'Use this timeline to predict rough windows before they become payout events.',
+                    child: _buildForecastCard(
+                      data.forecast,
+                      surfaceColor: surfaceColor,
+                      borderColor: borderColor,
+                      primaryText: primaryText,
+                      secondaryText: secondaryText,
                     ),
                   ),
-                  const SizedBox(width: 5),
+                  const SizedBox(height: 16),
+                  _buildReceiptCard(
+                    context,
+                    data.status,
+                    settledClaim,
+                    receiptAmount,
+                    receiptId,
+                    data.upiId,
+                  ),
+                  const SizedBox(height: 16),
+                  _buildPayoutVaultCard(data.payoutVault),
+                  const SizedBox(height: 16),
+                  _buildSafetyCard(
+                    context,
+                    data.safetyBanner,
+                    data.safetyDetail,
+                    data.zoneRisk,
+                  ),
+                  const SizedBox(height: 16),
+                  _buildZoneRadarCard(context, data.zoneRisk),
+                  const SizedBox(height: 16),
+                  _buildPremiumCard(context, data.plan, data.premiumBreakdown),
+                  const SizedBox(height: 16),
+                  _buildLedgerCard(context, data.claims),
+                  const SizedBox(height: 16),
+                  Showcase(
+                    key: _tourActionsKey,
+                    title: 'Quick Actions',
+                    description:
+                        'Use these two actions when you need to report mismatch or share live location instantly.',
+                    child: _buildQuickActions(context),
+                  ),
+                  const SizedBox(height: 22),
                   Text(
-                    isScheduled ? 'Inactive' : 'Active',
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                      color: Colors.white,
-                      letterSpacing: 0.3,
+                    'Touch first, text second. All critical actions stay in the bottom thumb zone.',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: secondaryText.withValues(alpha: 0.80),
+                      height: 1.3,
                     ),
+                    textAlign: TextAlign.center,
                   ),
                 ],
               ),
             ),
           ),
-          const SizedBox(height: 6),
-          Text(
-            isScheduled ? 'Scheduled plan' : 'Current plan',
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: Colors.white.withValues(alpha: 0.7),
-              letterSpacing: 0.5,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            planTitle,
-            style: const TextStyle(
-              fontSize: 42,
-              fontWeight: FontWeight.w800,
-              color: Colors.white,
-              letterSpacing: -1.0,
-              height: 1.0,
-            ),
-          ),
-          const SizedBox(height: 6),
-          Text(
-            isScheduled ? 'Coverage starts with the next weekly cycle.' : 'Coverage is live for the current weekly cycle.',
-            style: TextStyle(
-              fontSize: 13,
-              color: Colors.white.withValues(alpha: 0.85),
-              fontWeight: FontWeight.w500,
-              height: 1.2,
-            ),
-          ),
-          const SizedBox(height: 18),
-          // Buttons – ghost "View Details" and solid white "File a Claim".
-          Row(
-            children: [
-              Expanded(
-                child: SizedBox(
-                  height: 46,
-                  child: OutlinedButton.icon(
-                    onPressed: () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute<void>(
-                          builder: (_) => const CoverageStatusScreen(),
-                        ),
-                      );
-                    },
-                    icon: const Icon(Icons.description_outlined, size: 16),
-                    label: const Text('View Details'),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: Colors.white,
-                      side: BorderSide(
-                        color: Colors.white.withValues(alpha: 0.4),
-                      ),
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
-                      minimumSize: const Size(0, 44),
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      textStyle: const TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: SizedBox(
-                  height: 46,
-                  child: ElevatedButton.icon(
-                    onPressed: () => _showQuickClaimSheet(context),
-                    icon: const Icon(Icons.add, size: 16),
-                    label: const Text('File a Claim'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: const Color(0xFF0E6E56),
-                      elevation: 0,
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
-                      minimumSize: const Size(0, 44),
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      textStyle: const TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 
-  Widget _buildPaymentDuePrompt(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-      decoration: BoxDecoration(
-        color: AppColors.warningLight,
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: AppColors.warning.withValues(alpha: 0.25)),
-      ),
-      child: Row(
-        children: [
-          const Icon(Icons.payment_rounded, color: AppColors.warning, size: 20),
-          const SizedBox(width: 10),
-          const Expanded(
-            child: Text(
-              'Payment due for the upcoming weekly cycle. Complete payment to activate cover.',
-              style: TextStyle(
-                fontSize: 13,
-                color: AppColors.textPrimary,
-                fontWeight: FontWeight.w600,
-                height: 1.3,
-              ),
-            ),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (_) => const CoverageStatusScreen(),
-                ),
-              );
-            },
-            child: const Text('Details'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  String _coerceDateString(Object? value, {Object? fallback}) {
-    final primary = value?.toString().trim() ?? '';
-    if (primary.isNotEmpty) {
-      return primary;
-    }
-    final secondary = fallback?.toString().trim() ?? '';
-    return secondary;
-  }
-
-  String _coerceText(Object? value, {String fallback = ''}) {
-    final parsed = value?.toString().trim() ?? '';
-    return parsed.isEmpty ? fallback : parsed;
-  }
-
-  String _shiftDateString(String value, {required int days}) {
-    final parsed = DateTime.tryParse(value);
-    if (parsed == null) {
-      return value;
-    }
-    return parsed.toUtc().add(Duration(days: days)).toIso8601String();
-  }
-
-  String _fallbackNextBillingDateString() {
-    return DateTime.now().toUtc().add(const Duration(days: 7)).toIso8601String();
-  }
-
-  String _formatDateLabel(String value) {
-    final parsed = DateTime.tryParse(value);
-    if (parsed == null) {
-      return value.isEmpty ? 'Not set' : value;
-    }
-    return DateFormat('MMM d, y').format(parsed.toLocal());
-  }
-
-  // ─── Today's updates ──────────────────────────────────────────────────────
-
-  Widget _buildTodaysUpdatesSnapshot(Claim? latestClaim) {
-    final hasUpdates = latestClaim != null;
-    final claim = latestClaim;
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: AppColors.cardBackground,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
-            "Today's updates",
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.w800,
-              color: AppColors.textPrimary,
-            ),
-          ),
-          const SizedBox(height: 2),
-          const Text(
-            'Latest claim activity for your account',
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w500,
-              color: AppColors.textSecondary,
-            ),
-          ),
-          const SizedBox(height: 12),
-          if (!hasUpdates)
-            Row(
-              children: [
-                Container(
-                  width: 32,
-                  height: 32,
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFEAF3DE),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: const Icon(
-                    Icons.verified_outlined,
-                    size: 16,
-                    color: Color(0xFF3B6D11),
-                  ),
-                ),
-                const SizedBox(width: 10),
-                const Expanded(
-                  child: Text(
-                    'No claims found yet. Your latest claim will show here.',
-                    style: TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                      color: AppColors.success,
-                      height: 1.4,
-                    ),
-                  ),
-                ),
-              ],
-            )
-          else if (claim != null)
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  width: 32,
-                  height: 32,
-                  decoration: BoxDecoration(
-                    color: claim.typeColor.withValues(alpha: 0.14),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Icon(
-                    claim.typeIcon,
-                    size: 16,
-                    color: claim.typeColor,
-                  ),
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        '${claim.typeShortName} · ${claim.id}',
-                        style: const TextStyle(
-                          fontSize: 13,
-                          fontWeight: FontWeight.w700,
-                          color: AppColors.textPrimary,
-                        ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        '${DateFormat('EEE, d MMM').format(claim.date)} · ${claim.statusLabel}',
-                        style: const TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w500,
-                          color: AppColors.textSecondary,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        '₹${NumberFormat('#,##0').format(claim.amount)} credited for ${claim.typeName.toLowerCase()}.',
-                        style: const TextStyle(
-                          fontSize: 13,
-                          fontWeight: FontWeight.w500,
-                          color: AppColors.textSecondary,
-                          height: 1.4,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-        ],
-      ),
-    );
-  }
-
-  // ─── Quick actions ────────────────────────────────────────────────────────
-
-  Widget _buildQuickActions(BuildContext context) {
-    return GridView.count(
-      physics: const NeverScrollableScrollPhysics(),
-      shrinkWrap: true,
-      crossAxisCount: 2,
-      mainAxisSpacing: 10,
-      crossAxisSpacing: 10,
-      childAspectRatio: 1.35,
-      children: [
-        _quickAccessTile(
-          icon: Icons.emergency_outlined,
-          label: 'Emergency',
-          subtitle: 'Tap to get help',
-          iconBackground: const Color(0xFFFCEBEB),
-          iconColor: const Color(0xFFA32D2D),
-          onTap: () => _showSupportSheet(context),
-        ),
-        _quickAccessTile(
-          icon: Icons.health_and_safety_outlined,
-          label: 'Medical help',
-          subtitle: 'Find support',
-          iconBackground: const Color(0xFFE6F1FB),
-          iconColor: const Color(0xFF185FA5),
-          onTap: () => _showSupportSheet(context),
-        ),
-        _quickAccessTile(
-          icon: Icons.inventory_2_outlined,
-          label: 'Gear assist',
-          subtitle: 'File a claim',
-          iconBackground: const Color(0xFFEAF3DE),
-          iconColor: const Color(0xFF3B6D11),
-          onTap: () => _showQuickClaimSheet(context),
-        ),
-        _quickAccessTile(
-          icon: Icons.tips_and_updates_outlined,
-          label: 'Safety tips',
-          subtitle: 'View advisories',
-          iconBackground: const Color(0xFFFAEEDA),
-          iconColor: const Color(0xFFBA7517),
-          onTap: () => _showNotificationsSheet(context),
-        ),
-      ],
-    );
-  }
-
-  Widget _quickAccessTile({
-    required IconData icon,
-    required String label,
-    required String subtitle,
-    required Color iconBackground,
-    required Color iconColor,
-    required VoidCallback onTap,
+  Widget _buildHeader(
+    _DashboardData data, {
+    required Color elevatedSurface,
+    required Color borderColor,
+    required Color primaryText,
+    required Color secondaryText,
   }) {
-    return InkWell(
-      borderRadius: BorderRadius.circular(16),
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(12, 12, 10, 10),
-        decoration: BoxDecoration(
-          color: AppColors.cardBackground,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: AppColors.border),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Container(
-              width: 30,
-              height: 30,
-              decoration: BoxDecoration(
-                color: iconBackground,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Icon(icon, size: 16, color: iconColor),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              label,
-              style: const TextStyle(
-                fontSize: 16,
-                height: 1.1,
-                fontWeight: FontWeight.w700,
-                color: AppColors.textPrimary,
-              ),
-            ),
-            const SizedBox(height: 3),
-            Text(
-              subtitle,
-              style: const TextStyle(
-                fontSize: 12,
-                color: AppColors.textSecondary,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  // ─── Metrics row ──────────────────────────────────────────────────────────
-
-  Widget _buildMetricsRow(
-    User user,
-    NumberFormat currencyFormat, {
-    required double earningsProtected,
-    required double? totalEarnings,
-  }) {
+    final zone = _coerceString(data.user.zone, fallback: 'Zone not set');
     return Row(
       children: [
-        Expanded(
-          child: _metricCard(
-            title: 'Earnings Protected',
-            value: '₹${currencyFormat.format(earningsProtected)}',
-            subtitle: 'Parametric coverage active',
-            icon: Icons.shield,
-            iconBackground: AppColors.accentLight,
-            iconColor: AppColors.primary,
+        Container(
+          width: 52,
+          height: 52,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(18),
+            gradient: const LinearGradient(
+              colors: [AppColors.neonGreen, AppColors.neonCyan],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+          ),
+          child: const Icon(
+            Icons.electric_bike_rounded,
+            color: Colors.black,
+            size: 28,
           ),
         ),
-        const SizedBox(width: 12),
+        const SizedBox(width: 14),
         Expanded(
-          child: _metricCard(
-            title: 'Total Earnings',
-            value:
-                totalEarnings == null ? 'Not Synced' : '₹${currencyFormat.format(totalEarnings)}',
-            subtitle: totalEarnings == null
-                ? 'Pending sync from ${user.platform}'
-                : 'Synced from ${user.platform}',
-            icon: Icons.account_balance_wallet_outlined,
-            iconBackground: AppColors.infoLight,
-            iconColor: AppColors.info,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Good shift, ${_shortName(data.user.name)}',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                  color: primaryText,
+                  letterSpacing: -0.2,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(zone, style: TextStyle(fontSize: 12, color: secondaryText)),
+            ],
           ),
         ),
-      ],
-    );
-  }
-
-  Widget _metricCard({
-    required String title,
-    required String value,
-    required String subtitle,
-    required IconData icon,
-    required Color iconBackground,
-    required Color iconColor,
-  }) {
-    return Container(
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: AppColors.cardBackground,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Container(
-            width: 30,
-            height: 30,
+        InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: () => TabRouter.switchTo(3),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
             decoration: BoxDecoration(
-              color: iconBackground,
-              borderRadius: BorderRadius.circular(9),
+              color: elevatedSurface,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: borderColor),
             ),
-            child: Icon(icon, size: 16, color: iconColor),
-          ),
-          const SizedBox(height: 10),
-          Text(
-            title.toUpperCase(),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              fontSize: 10,
-              fontWeight: FontWeight.w700,
-              color: AppColors.textTertiary,
-              letterSpacing: 0.7,
+            child: Text(
+              'Wallet',
+              style: TextStyle(color: primaryText, fontWeight: FontWeight.w700),
             ),
           ),
-          const SizedBox(height: 6),
-          Text(
-            value,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.w800,
-              color: AppColors.textPrimary,
-              letterSpacing: -0.2,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            subtitle,
-            style: const TextStyle(
-              fontSize: 11,
-              color: AppColors.textSecondary,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  // ─── Weekly snapshot ──────────────────────────────────────────────────────
-
-  Widget _buildWeeklySnapshot(
-    NumberFormat currencyFormat, {
-    required int coveredDaysLeft,
-    required int claimsProcessedThisWeek,
-    required double payoutThisWeek,
-  }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: _miniStatCard(
-                title: 'Covered Days Left',
-                value: '$coveredDaysLeft',
-                icon: Icons.calendar_today_outlined,
-                iconColor: AppColors.info,
-                iconBackground: AppColors.infoLight,
-              ),
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: _miniStatCard(
-                title: 'Claims Processed',
-                value: '$claimsProcessedThisWeek',
-                icon: Icons.verified_outlined,
-                iconColor: AppColors.success,
-                iconBackground: AppColors.successLight,
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 10),
-        _miniStatCard(
-          title: 'Payout This Week',
-          value: '₹${currencyFormat.format(payoutThisWeek)}',
-          icon: Icons.payments_outlined,
-          iconColor: AppColors.primary,
-          iconBackground: AppColors.accentLight,
         ),
       ],
     );
   }
 
-  Widget _miniStatCard({
-    required String title,
-    required String value,
-    required IconData icon,
-    required Color iconColor,
-    required Color iconBackground,
+  Widget _buildStatusBanner(
+    _RiskStatus status, {
+    required Color primaryText,
+    required Color secondaryText,
   }) {
     return Container(
-      width: double.infinity,
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: AppColors.cardBackground,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: AppColors.border),
+        color: status.color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: status.color.withValues(alpha: 0.30)),
       ),
       child: Row(
         children: [
           Container(
-            width: 30,
-            height: 30,
+            width: 12,
+            height: 12,
             decoration: BoxDecoration(
-              color: iconBackground,
-              borderRadius: BorderRadius.circular(8),
+              color: status.color,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: status.color.withValues(alpha: 0.6),
+                  blurRadius: 16,
+                ),
+              ],
             ),
-            child: Icon(icon, size: 16, color: iconColor),
           ),
-          const SizedBox(width: 10),
+          const SizedBox(width: 12),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  title,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    fontSize: 11,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.textSecondary,
-                  ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  value,
-                  style: const TextStyle(
-                    fontSize: 17,
+                  status.label,
+                  style: TextStyle(
+                    color: primaryText,
+                    fontSize: 15,
                     fontWeight: FontWeight.w800,
-                    color: AppColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  status.summary,
+                  style: TextStyle(
+                    color: secondaryText,
+                    fontSize: 12,
+                    height: 1.25,
                   ),
                 ),
               ],
@@ -1350,169 +784,456 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  // ─── Recent claims ────────────────────────────────────────────────────────
-
-  Widget _buildRecentClaims(
-    List<Claim> claims,
-    NumberFormat currencyFormat,
-    DateFormat dateFormat,
-  ) {
-    final recentClaims = claims.toList()
-      ..sort((left, right) => right.date.compareTo(left.date));
-
-    final latestClaim = recentClaims.take(1).toList();
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppColors.cardBackground,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (latestClaim.isEmpty)
-            const Text(
-              'No claims yet',
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: AppColors.textSecondary,
+  Widget _buildTriggerPills(
+    BuildContext context,
+    List<_RiskMetric> metrics, {
+    required Color surfaceColor,
+    required Color primaryText,
+    required Color secondaryText,
+  }) {
+    return Row(
+      children: metrics
+          .map(
+            (metric) => Expanded(
+              child: Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(18),
+                  onTap: () => _showMetricSheet(context, metric, null),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 12,
+                    ),
+                    decoration: BoxDecoration(
+                      color: surfaceColor,
+                      borderRadius: BorderRadius.circular(18),
+                      border: Border.all(
+                        color: metric.color.withValues(alpha: 0.20),
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(metric.icon, color: metric.color, size: 18),
+                        const SizedBox(height: 8),
+                        Text(
+                          metric.label,
+                          style: TextStyle(
+                            color: primaryText,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          '${metric.displayValue} / ${metric.thresholdDisplay}',
+                          style: TextStyle(color: secondaryText, fontSize: 11),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
               ),
-            )
-          else
-            ...latestClaim.map(
-            (claim) => Row(
-              children: [
-                Container(
-                  width: 34,
-                  height: 34,
-                  decoration: BoxDecoration(
-                    color: claim.typeColor.withValues(alpha: 0.14),
-                    borderRadius: BorderRadius.circular(9),
-                  ),
-                  child: Icon(claim.typeIcon, size: 18, color: claim.typeColor),
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        '${claim.typeShortName} · ${claim.id}',
-                        style: const TextStyle(
-                          fontSize: 13,
-                          fontWeight: FontWeight.w700,
-                          color: AppColors.textPrimary,
-                        ),
-                      ),
-                      Text(
-                        dateFormat.format(claim.date),
-                        style: const TextStyle(
-                          fontSize: 11,
-                          color: AppColors.textSecondary,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    Text(
-                      '₹${currencyFormat.format(claim.amount)}',
-                      style: const TextStyle(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w700,
-                        color: AppColors.textPrimary,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 3),
-                      decoration: BoxDecoration(
-                        color: claim.statusColor.withValues(alpha: 0.14),
-                        borderRadius: BorderRadius.circular(999),
-                      ),
-                      child: Text(
-                        claim.statusLabel,
-                        style: TextStyle(
-                          fontSize: 10,
-                          fontWeight: FontWeight.w600,
-                          color: claim.statusColor,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ],
             ),
-          ),
-        ],
-      ),
+          )
+          .toList(),
     );
   }
 
-  // ─── Next billing ─────────────────────────────────────────────────────────
-
-  Widget _buildNextBillingCard(BuildContext context, InsurancePlan activePlan) {
-    final nextDebitDate = DateFormat('EEE, d MMM')
-        .format(DateTime.now().add(const Duration(days: 3)));
-
+  Widget _buildForecastCard(
+    List<_ForecastBlock> forecast, {
+    required Color surfaceColor,
+    required Color borderColor,
+    required Color primaryText,
+    required Color secondaryText,
+  }) {
     return Container(
-      width: double.infinity,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: AppColors.cardBackground,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: AppColors.border),
+        color: surfaceColor,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: borderColor),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            '₹${activePlan.weeklyPremium} auto-debit on $nextDebitDate',
-            style: const TextStyle(
-              fontSize: 13,
-              color: AppColors.textSecondary,
+            'Shift Forecaster',
+            style: TextStyle(
+              color: primaryText,
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
             ),
           ),
+          const SizedBox(height: 4),
+          Text(
+            '12-hour risk timeline for the next shift window.',
+            style: TextStyle(color: secondaryText, fontSize: 12),
+          ),
+          const SizedBox(height: 14),
+          SizedBox(
+            height: 110,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              itemCount: forecast.length,
+              separatorBuilder: (_, _) => const SizedBox(width: 8),
+              itemBuilder: (context, index) {
+                final block = forecast[index];
+                return Container(
+                  width: 70,
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: block.color.withValues(alpha: 0.16),
+                    borderRadius: BorderRadius.circular(18),
+                    border: Border.all(
+                      color: block.color.withValues(alpha: 0.30),
+                    ),
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        block.label,
+                        style: TextStyle(
+                          color: primaryText,
+                          fontSize: 11,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      Container(
+                        height: 36,
+                        width: double.infinity,
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(12),
+                          gradient: LinearGradient(
+                            colors: [
+                              block.shimmer.withValues(alpha: 0.22),
+                              block.color,
+                            ],
+                            begin: Alignment.topLeft,
+                            end: Alignment.bottomRight,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        block.caption,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(color: secondaryText, fontSize: 10),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNearMissCard(
+    BuildContext context,
+    _NearMissSignal signal, {
+    required Color surfaceColor,
+    required Color elevatedSurface,
+    required Color primaryText,
+    required Color secondaryText,
+  }) {
+    final ratio = signal.metric.ratio.clamp(0.0, 1.2).toDouble();
+    final progress = (ratio / 1.0).clamp(0.0, 1.0).toDouble();
+    final remaining = math.max(0, signal.monitoringMinutes);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: surfaceColor,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.neonAmber.withValues(alpha: 0.26)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Near-Miss Tracker',
+            style: TextStyle(
+              color: primaryText,
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '${signal.metric.label} is close to threshold. Monitoring window: ${remaining}m.',
+            style: TextStyle(color: secondaryText, fontSize: 12),
+          ),
           const SizedBox(height: 12),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final width = constraints.maxWidth;
+              final markerX = width - 2;
+              final progressWidth = width * progress;
+              return Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  Container(
+                    height: 14,
+                    width: width,
+                    decoration: BoxDecoration(
+                      color: elevatedSurface,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                  Container(
+                    height: 14,
+                    width: progressWidth,
+                    decoration: BoxDecoration(
+                      gradient: const LinearGradient(
+                        colors: [AppColors.neonCyan, AppColors.neonAmber],
+                      ),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                  Positioned(
+                    left: markerX,
+                    top: -6,
+                    bottom: -6,
+                    child: Container(
+                      width: 2,
+                      decoration: BoxDecoration(
+                        color: secondaryText.withValues(alpha: 0.76),
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Text(
+                '${signal.metric.displayValue} now',
+                style: TextStyle(
+                  color: primaryText,
+                  fontWeight: FontWeight.w700,
+                  fontSize: 12,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                'Threshold ${signal.metric.thresholdDisplay}',
+                style: TextStyle(color: secondaryText, fontSize: 11),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton(
+              onPressed: () => _showMetricSheet(context, signal.metric, null),
+              child: const Text('Open Threshold Detail'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildReceiptCard(
+    BuildContext context,
+    _RiskStatus status,
+    _ClaimSnapshot? settledClaim,
+    double amount,
+    String referenceId,
+    String upiId,
+  ) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.70 : 0.78,
+    );
+    final cardBg = isDark ? AppColors.nightSurface : theme.colorScheme.surface;
+    final isPaid = settledClaim != null;
+    final accent = isPaid ? AppColors.neonGreen : status.color;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: accent.withValues(alpha: 0.24)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                isPaid
+                    ? Icons.verified_rounded
+                    : Icons.hourglass_bottom_rounded,
+                color: accent,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'Trigger Receipt',
+                style: TextStyle(
+                  color: primaryText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            isPaid
+                ? '₹${amount.toInt()} sent to $upiId'
+                : 'Waiting for the next crossed threshold.',
+            style: TextStyle(
+              color: primaryText,
+              fontSize: 20,
+              fontWeight: FontWeight.w900,
+              letterSpacing: -0.3,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            isPaid
+                ? 'Reference $referenceId · ${_formatDateTime(settledClaim.date)}'
+                : 'Exact measurement vs threshold stays visible until the system decides.',
+            style: TextStyle(color: secondaryText, fontSize: 12, height: 1.35),
+          ),
+          if (isPaid) ...[
+            const SizedBox(height: 12),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: AppColors.neonGreen.withValues(alpha: 0.10),
+                borderRadius: BorderRadius.circular(18),
+                border: Border.all(
+                  color: AppColors.neonGreen.withValues(alpha: 0.22),
+                ),
+              ),
+              child: Text(
+                'Glass-box detail: amount, destination, and timestamp are all visible here.',
+                style: TextStyle(
+                  color: theme.colorScheme.onSurface.withValues(
+                    alpha: isDark ? 0.88 : 0.92,
+                  ),
+                  fontSize: 12,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: () =>
+                        _showChaChingModal(context, amount, referenceId, upiId),
+                    icon: const Icon(Icons.payments_rounded),
+                    label: const Text('Cha-Ching View'),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: TextButton.icon(
+                    onPressed: () =>
+                        _downloadReceipt(context, referenceId, amount),
+                    icon: const Icon(Icons.download_rounded),
+                    label: const Text('Download receipt'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPayoutVaultCard(_PayoutVault vault) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final cardBg = isDark ? AppColors.nightSurface : theme.colorScheme.surface;
+    final cardBorder = isDark
+        ? AppColors.nightBorder
+        : theme.colorScheme.outline.withValues(alpha: 0.28);
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.62 : 0.74,
+    );
+    final secured = vault.securedAmount;
+    final potential = vault.potentialAmount;
+    final ratio = vault.securedRatio;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Payout Vault',
+            style: TextStyle(
+              color: primaryText,
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Secured vs potential payout, always visible.',
+            style: TextStyle(color: secondaryText, fontSize: 12),
+          ),
+          const SizedBox(height: 14),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: SizedBox(
+              height: 18,
+              child: Row(
+                children: [
+                  Expanded(
+                    flex: math.max(1, (ratio * 100).round()),
+                    child: Container(color: AppColors.neonGreen),
+                  ),
+                  Expanded(
+                    flex: math.max(1, ((1 - ratio) * 100).round()),
+                    child: Container(
+                      color: AppColors.neonAmber.withValues(alpha: 0.75),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
           Row(
             children: [
               Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => _openCoverage(context),
-                  icon: const Icon(Icons.tune, size: 18),
-                  label: const Text('Manage Plan'),
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: AppColors.primary,
-                    side: const BorderSide(color: AppColors.border),
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                  ),
+                child: _vaultMetric(
+                  context: context,
+                  label: 'Secured',
+                  value: _currency.format(secured),
+                  color: AppColors.neonGreen,
                 ),
               ),
               const SizedBox(width: 10),
               Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => _showSupportSheet(context),
-                  icon: const Icon(Icons.chat_bubble_outline, size: 18),
-                  label: const Text('Support'),
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: AppColors.primary,
-                    side: const BorderSide(color: AppColors.border),
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                  ),
+                child: _vaultMetric(
+                  context: context,
+                  label: 'Potential',
+                  value: _currency.format(potential),
+                  color: AppColors.neonAmber,
                 ),
               ),
             ],
@@ -1522,418 +1243,434 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  // ─── Navigation helpers ───────────────────────────────────────────────────
-
-  void _openClaims(BuildContext context) => _switchToTab(context, 1);
-  void _openCoverage(BuildContext context) => _switchToTab(context, 2);
-  void _openProfile(BuildContext context) => _switchToTab(context, 4);
-  void _openPayouts(BuildContext context) => _switchToTab(context, 3);
-
-  Future<void> _copySupportValue(
-    BuildContext context, {
+  Widget _vaultMetric({
+    required BuildContext context,
     required String label,
     required String value,
-  }) async {
-    await Clipboard.setData(ClipboardData(text: value));
-    if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('$label copied: $value')),
-    );
-  }
-
-  void _switchToTab(BuildContext context, int index) {
-    TabRouter.switchTo(index);
-    Navigator.of(context).popUntil((route) => route.isFirst);
-  }
-
-  // ─── Bottom sheets ────────────────────────────────────────────────────────
-
-  void _showNotificationsSheet(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      builder: (sheetContext) {
-        return ListView(
-          shrinkWrap: true,
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
-          children: const [
-            ListTile(
-              leading: Icon(Icons.cloud_done_outlined),
-              title: Text("Today's risk data synced"),
-              subtitle: Text('Coverage triggers updated 5 min ago'),
-            ),
-            ListTile(
-              leading: Icon(Icons.account_balance_wallet_outlined),
-              title: Text('Weekly debit reminder'),
-              subtitle: Text('Premium auto-debit due in 3 days'),
-            ),
-            ListTile(
-              leading: Icon(Icons.support_agent_outlined),
-              title: Text('Support response available'),
-              subtitle: Text('A specialist replied to your last query'),
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  // ignore: unused_element
-  void _showQuickMenuSheet(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      builder: (sheetContext) {
-        return SafeArea(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ListTile(
-                leading: const Icon(Icons.person_outline),
-                title: const Text('Profile'),
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _openProfile(context);
-                },
-              ),
-              ListTile(
-                leading: const Icon(Icons.receipt_long_outlined),
-                title: const Text('Claims'),
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _openClaims(context);
-                },
-              ),
-              ListTile(
-                leading: const Icon(Icons.shield_outlined),
-                title: const Text('Coverage'),
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _openCoverage(context);
-                },
-              ),
-              ListTile(
-                leading: const Icon(Icons.payments_outlined),
-                title: const Text('Payouts'),
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _openPayouts(context);
-                },
-              ),
-            ],
+    required Color color,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bgColor = isDark
+        ? AppColors.nightSurfaceElevated
+        : Theme.of(
+            context,
+          ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.75);
+    final primaryText = Theme.of(context).colorScheme.onSurface;
+    final secondaryText = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.64 : 0.74);
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 9,
+            height: 9,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
           ),
-        );
-      },
-    );
-  }
-
-  void _showSupportSheet(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      builder: (sheetContext) {
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
+          const SizedBox(width: 8),
+          Expanded(
             child: Column(
-              mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text(
-                  'Support',
-                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+                Text(
+                  label,
+                  style: TextStyle(color: secondaryText, fontSize: 11),
                 ),
-                const SizedBox(height: 10),
-                const Text('Choose how you want help with your policy or claims.'),
-                const SizedBox(height: 12),
-                ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  leading: const Icon(Icons.call_outlined),
-                  title: const Text('Call support'),
-                  subtitle: const Text('+91 1800 00 0000'),
-                  onTap: () {
-                    Navigator.pop(sheetContext);
-                    _copySupportValue(
-                      context,
-                      label: 'Support helpline',
-                      value: '+91 1800 00 0000',
-                    );
-                  },
-                ),
-                ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  leading: const Icon(Icons.chat_outlined),
-                  title: const Text('Chat with us'),
-                  subtitle: const Text('support@saatdin.in'),
-                  onTap: () {
-                    Navigator.pop(sheetContext);
-                    _copySupportValue(
-                      context,
-                      label: 'Support email',
-                      value: 'support@saatdin.in',
-                    );
-                  },
-                ),
-                ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  leading: const Icon(Icons.help_outline),
-                  title: const Text('View claim guide'),
-                  subtitle: const Text('See how disputes are reviewed'),
-                  onTap: () {
-                    Navigator.pop(sheetContext);
-                    _openCoverage(context);
-                  },
+                const SizedBox(height: 2),
+                Text(
+                  value,
+                  style: TextStyle(
+                    color: primaryText,
+                    fontWeight: FontWeight.w800,
+                  ),
                 ),
               ],
             ),
           ),
-        );
-      },
+        ],
+      ),
     );
   }
 
-  void _showQuickClaimSheet(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      builder: (sheetContext) {
-        return SafeArea(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
+  Widget _buildSafetyCard(
+    BuildContext context,
+    String banner,
+    String detail,
+    ZoneRisk? zoneRisk,
+  ) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.68 : 0.76,
+    );
+    final cardBg = isDark ? AppColors.nightSurface : theme.colorScheme.surface;
+    final cardBorder = isDark
+        ? AppColors.nightBorder
+        : theme.colorScheme.outline.withValues(alpha: 0.28);
+    final tier = zoneRisk?.riskTier ?? 'MEDIUM';
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
             children: [
-              ListTile(
-                leading: const Icon(Icons.report_problem_outlined),
-                title: const Text('Raise payout dispute'),
-                subtitle: const Text('Missing trigger or delayed payout'),
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _openClaims(context);
-                },
+              const Icon(
+                Icons.shield_moon_rounded,
+                color: AppColors.neonCyan,
+                size: 20,
               ),
-              ListTile(
-                leading: const Icon(Icons.payments_outlined),
-                title: const Text('Open payouts ledger'),
-                subtitle: const Text('Track your latest credits and status'),
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _openPayouts(context);
-                },
+              const SizedBox(width: 8),
+              Text(
+                'Safety Banner',
+                style: TextStyle(
+                  color: primaryText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w800,
+                ),
               ),
-              ListTile(
-                leading: const Icon(Icons.support_agent_outlined),
-                title: const Text('Contact support'),
-                subtitle: const Text('Talk to a specialist'),
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _showSupportSheet(context);
-                },
+              const Spacer(),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.neonCyan.withValues(alpha: 0.14),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: Text(
+                  tier,
+                  style: const TextStyle(
+                    color: AppColors.neonCyan,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
               ),
             ],
           ),
-        );
-      },
+          const SizedBox(height: 12),
+          Text(
+            banner,
+            style: TextStyle(
+              color: primaryText,
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              height: 1.35,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            detail,
+            style: TextStyle(color: secondaryText, fontSize: 12, height: 1.35),
+          ),
+        ],
+      ),
     );
   }
 
-  // ─── Primary actions ──────────────────────────────────────────────────────
+  Widget _buildZoneRadarCard(BuildContext context, ZoneRisk? zoneRisk) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.62 : 0.74,
+    );
+    final cardBg = isDark ? AppColors.nightSurface : theme.colorScheme.surface;
+    final cardBorder = isDark
+        ? AppColors.nightBorder
+        : theme.colorScheme.outline.withValues(alpha: 0.28);
+    final rain = zoneRisk?.floodRiskScore ?? 32;
+    final aqi = zoneRisk?.aqiRiskScore ?? 28;
+    final traffic = zoneRisk?.trafficCongestionScore ?? 40;
+    final composite = zoneRisk?.compositeRiskScore ?? 35;
 
-  Widget _buildPrimaryActions(BuildContext context) {
-    return Column(
-      children: [
-        InkWell(
-          borderRadius: BorderRadius.circular(18),
-          onTap: () {
-            _showQuickClaimSheet(context);
-          },
-          child: Container(
-            width: double.infinity,
-            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
-            decoration: BoxDecoration(
-              color: AppColors.primary,
-              borderRadius: BorderRadius.circular(18),
+    final points = <_RadarPoint>[
+      _RadarPoint(label: 'Rain', value: rain),
+      _RadarPoint(label: 'AQI', value: aqi),
+      _RadarPoint(label: 'Traffic', value: traffic),
+      _RadarPoint(label: 'Composite', value: composite),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Zone Risk Radar',
+            style: TextStyle(
+              color: primaryText,
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
             ),
-            child: const Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Column(
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Live risk fingerprint for your delivery zone.',
+            style: TextStyle(color: secondaryText, fontSize: 12),
+          ),
+          const SizedBox(height: 12),
+          GridView.builder(
+            itemCount: points.length,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              childAspectRatio: 1.9,
+              crossAxisSpacing: 10,
+              mainAxisSpacing: 10,
+            ),
+            itemBuilder: (context, index) {
+              final point = points[index];
+              final tone = _riskTone(point.value);
+              return Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: tone.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(14),
+                  border: Border.all(color: tone.withValues(alpha: 0.24)),
+                ),
+                child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'Raise Dispute',
+                      point.label,
                       style: TextStyle(
-                        fontSize: 17,
+                        color: primaryText,
                         fontWeight: FontWeight.w700,
-                        color: Colors.white,
                       ),
                     ),
-                    SizedBox(height: 3),
+                    const Spacer(),
                     Text(
-                      'Report missed trigger or payout issue',
+                      '${point.value.toStringAsFixed(0)} / 100',
                       style: TextStyle(
-                        fontSize: 12,
-                        color: Colors.white70,
+                        color: primaryText.withValues(alpha: 0.88),
+                        fontWeight: FontWeight.w700,
                       ),
                     ),
                   ],
                 ),
-                Icon(Icons.arrow_forward_rounded, color: Colors.white),
-              ],
-            ),
+              );
+            },
           ),
-        ),
-        const SizedBox(height: 10),
-        Row(
-          children: [
-            Expanded(
-              child: OutlinedButton.icon(
-                onPressed: () {
-                  _openCoverage(context);
-                },
-                icon: const Icon(Icons.description_outlined, size: 18),
-                label: const Text('Coverage'),
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: AppColors.primary,
-                  side: const BorderSide(color: AppColors.border),
-                  padding: const EdgeInsets.symmetric(vertical: 13),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(14),
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: OutlinedButton.icon(
-                onPressed: () {
-                  _openClaims(context);
-                },
-                icon: const Icon(Icons.history, size: 18),
-                label: const Text('History'),
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: AppColors.primary,
-                  side: const BorderSide(color: AppColors.border),
-                  padding: const EdgeInsets.symmetric(vertical: 13),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(14),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ],
+        ],
+      ),
     );
   }
 
-  // ─── Section header ───────────────────────────────────────────────────────
-
-  Widget _buildSectionHeader(
-    String title, {
-    String? actionText,
-    VoidCallback? onTap,
-  }) {
-    return Row(
-      children: [
-        Expanded(
-          child: Text(
-            title,
-            style: const TextStyle(
+  Widget _buildPremiumCard(
+    BuildContext context,
+    InsurancePlan plan,
+    List<_AllocationSlice> allocation,
+  ) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.62 : 0.74,
+    );
+    final cardBg = isDark ? AppColors.nightSurface : theme.colorScheme.surface;
+    final cardBorder = isDark
+        ? AppColors.nightBorder
+        : theme.colorScheme.outline.withValues(alpha: 0.28);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Premium Allocation',
+            style: TextStyle(
+              color: primaryText,
               fontSize: 16,
-              fontWeight: FontWeight.w700,
-              color: AppColors.textPrimary,
+              fontWeight: FontWeight.w800,
             ),
           ),
-        ),
-        if (actionText != null)
-          TextButton(
-            onPressed: onTap ?? () {},
-            style: TextButton.styleFrom(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              minimumSize: const Size(0, 36),
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-            child: Text(
-              actionText,
-              style: const TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-                color: AppColors.primary,
+          const SizedBox(height: 4),
+          Text(
+            '₹${plan.weeklyPremium}/week · Max payout ₹${plan.perTriggerPayout}',
+            style: TextStyle(color: secondaryText, fontSize: 12),
+          ),
+          const SizedBox(height: 14),
+          Row(
+            children: [
+              SizedBox(
+                width: 122,
+                height: 122,
+                child: CustomPaint(
+                  painter: _AllocationDonutPainter(allocation),
+                  child: Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          '₹35',
+                          style: TextStyle(
+                            color: primaryText,
+                            fontSize: 22,
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                        SizedBox(height: 2),
+                        Text(
+                          'weekly shield',
+                          style: TextStyle(color: secondaryText, fontSize: 10),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
               ),
-            ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  children: allocation.map((slice) {
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 10),
+                      child: Row(
+                        children: [
+                          Container(
+                            width: 10,
+                            height: 10,
+                            decoration: BoxDecoration(
+                              color: slice.color,
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                          Expanded(
+                            child: Text(
+                              slice.label,
+                              style: TextStyle(
+                                color: primaryText,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                          Text(
+                            '${slice.share}%',
+                            style: TextStyle(
+                              color: primaryText.withValues(alpha: 0.76),
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }).toList(),
+                ),
+              ),
+            ],
           ),
-      ],
+        ],
+      ),
     );
   }
 
-  // ─── Account options sheet ────────────────────────────────────────────────
+  Widget _buildLedgerCard(BuildContext context, List<Claim> claims) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final cardBg = isDark ? AppColors.nightSurface : theme.colorScheme.surface;
+    final elevatedBg = isDark
+        ? AppColors.nightSurfaceElevated
+        : theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.75);
+    final cardBorder = isDark
+        ? AppColors.nightBorder
+        : theme.colorScheme.outline.withValues(alpha: 0.28);
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.64 : 0.74,
+    );
+    final ordered = claims.toList()
+      ..sort((left, right) => right.date.compareTo(left.date));
+    final recent = ordered.take(4).toList();
 
-  // ignore: unused_element
-  void _showAccountOptions(BuildContext context, User user) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (sheetContext) {
-        return Container(
-          height: MediaQuery.of(sheetContext).size.height * 0.82,
-          decoration: const BoxDecoration(
-            color: AppColors.scaffoldBackground,
-            borderRadius: BorderRadius.vertical(top: Radius.circular(26)),
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Claim Ledger',
+                style: TextStyle(
+                  color: primaryText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const Spacer(),
+              TextButton(
+                onPressed: () => TabRouter.switchTo(1),
+                child: const Text('Open claims'),
+              ),
+            ],
           ),
-          child: SafeArea(
-            top: false,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Center(
-                    child: Container(
-                      width: 42,
-                      height: 4,
-                      decoration: BoxDecoration(
-                        color: AppColors.border,
-                        borderRadius: BorderRadius.circular(999),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  const Text(
-                    'Account',
-                    style: TextStyle(
-                      fontSize: 34,
-                      fontWeight: FontWeight.w800,
-                      color: AppColors.textPrimary,
-                      letterSpacing: -0.6,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  Container(
-                    width: double.infinity,
-                    padding: const EdgeInsets.all(16),
+          const SizedBox(height: 8),
+          if (recent.isEmpty)
+            _emptyState(
+              context: context,
+              icon: Icons.receipt_long_rounded,
+              title: 'No ledger yet',
+              message: 'Settled payouts and threshold checks will appear here.',
+            )
+          else
+            Column(
+              children: recent.map((claim) {
+                final statusColor = _statusColor(claim.status);
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 10),
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: AppColors.cardBackground,
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(color: AppColors.border),
+                      color: elevatedBg,
+                      borderRadius: BorderRadius.circular(18),
+                      border: Border.all(
+                        color: statusColor.withValues(alpha: 0.18),
+                      ),
                     ),
                     child: Row(
                       children: [
                         Container(
-                          width: 52,
-                          height: 52,
-                          decoration: const BoxDecoration(
-                            color: AppColors.primary,
+                          width: 40,
+                          height: 40,
+                          decoration: BoxDecoration(
+                            color: statusColor.withValues(alpha: 0.14),
                             shape: BoxShape.circle,
                           ),
-                          child: Center(
-                            child: Text(
-                              user.name.substring(0, 1).toUpperCase(),
-                              style: const TextStyle(
-                                fontSize: 24,
-                                fontWeight: FontWeight.w600,
-                                color: Colors.white,
-                              ),
-                            ),
+                          child: Icon(
+                            claim.typeIcon,
+                            color: statusColor,
+                            size: 20,
                           ),
                         ),
                         const SizedBox(width: 12),
@@ -1942,119 +1679,449 @@ class HomeScreen extends StatelessWidget {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
-                                user.name,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
-                                  fontSize: 20,
-                                  fontWeight: FontWeight.w700,
-                                  color: AppColors.textPrimary,
-                                  letterSpacing: -0.2,
+                                claim.typeName,
+                                style: TextStyle(
+                                  color: primaryText,
+                                  fontWeight: FontWeight.w800,
                                 ),
                               ),
-                              const SizedBox(height: 2),
+                              const SizedBox(height: 3),
                               Text(
-                                user.phone,
-                                style: const TextStyle(
-                                  fontSize: 15,
-                                  color: AppColors.textSecondary,
+                                '${_formatShortDate(claim.date)} · ${claim.description.isEmpty ? claim.statusLabel : claim.description}',
+                                style: TextStyle(
+                                  color: secondaryText,
+                                  fontSize: 12,
                                 ),
                               ),
                             ],
                           ),
                         ),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              _currency.format(claim.amount),
+                              style: TextStyle(
+                                color: primaryText,
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: statusColor.withValues(alpha: 0.14),
+                                borderRadius: BorderRadius.circular(999),
+                              ),
+                              child: Text(
+                                claim.statusLabel,
+                                style: TextStyle(
+                                  color: statusColor,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w800,
+                                ),
+                              ),
+                            ),
+                            if (claim.status == ClaimStatus.settled) ...[
+                              const SizedBox(height: 4),
+                              InkWell(
+                                onTap: () => _downloadReceipt(
+                                  context,
+                                  claim.id,
+                                  claim.amount,
+                                ),
+                                borderRadius: BorderRadius.circular(10),
+                                child: Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 6,
+                                    vertical: 2,
+                                  ),
+                                  child: Text(
+                                    'Receipt',
+                                    style: TextStyle(
+                                      color: primaryText.withValues(
+                                        alpha: 0.84,
+                                      ),
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w700,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
                       ],
                     ),
                   ),
-                  const SizedBox(height: 22),
-                  const Text(
-                    'Manage',
+                );
+              }).toList(),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildQuickActions(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Row(
+      children: [
+        Expanded(
+          child: _QuickActionButton(
+            icon: Icons.report_gmailerrorred_rounded,
+            label: 'Report discrepancy',
+            color: isDark ? AppColors.neonAmber : AppColors.warning,
+            onTap: () => _showDiscrepancySheet(context),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: _QuickActionButton(
+            icon: Icons.my_location_rounded,
+            label: 'Share live location',
+            color: isDark ? AppColors.neonGreen : AppColors.success,
+            onTap: () => _showVerificationSheet(context),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _emptyState({
+    required BuildContext context,
+    required IconData icon,
+    required String title,
+    required String message,
+  }) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final bg = isDark
+        ? AppColors.nightSurfaceElevated
+        : theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.75);
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.62 : 0.74,
+    );
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Column(
+        children: [
+          Icon(icon, color: secondaryText, size: 28),
+          const SizedBox(height: 8),
+          Text(
+            title,
+            style: TextStyle(color: primaryText, fontWeight: FontWeight.w800),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: TextStyle(color: secondaryText, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showMetricSheet(
+    BuildContext context,
+    _RiskMetric? metric,
+    _RiskStatus? status,
+  ) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final sheetBg = isDark
+        ? AppColors.nightSurface
+        : Theme.of(context).colorScheme.surface;
+    final primaryText = Theme.of(context).colorScheme.onSurface;
+    final secondaryText = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: isDark ? 0.72 : 0.84);
+    final title = metric?.label ?? status?.label ?? 'Risk detail';
+    final body = metric?.detail ?? status?.summary ?? 'No detail available.';
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: sheetBg,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      builder: (context) {
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 44,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: secondaryText.withValues(alpha: 0.34),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
+              Text(
+                title,
+                style: TextStyle(
+                  color: primaryText,
+                  fontSize: 20,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(body, style: TextStyle(color: secondaryText, height: 1.35)),
+              if (metric != null) ...[
+                const SizedBox(height: 16),
+                _readingRow('Current', metric.displayValue),
+                _readingRow('Threshold', metric.thresholdDisplay),
+                _readingRow('Gap', metric.gapDisplay),
+              ],
+              const SizedBox(height: 18),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Close'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _showDiscrepancySheet(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final sheetBg = isDark ? AppColors.nightSurface : theme.colorScheme.surface;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.68 : 0.78,
+    );
+    final chipBg = isDark
+        ? AppColors.nightSurfaceElevated
+        : theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.75);
+    String? selectedReason;
+    final options = <String>[
+      'Rain heavier',
+      'Traffic stopped',
+      'Heat extreme',
+      'AQI spike',
+    ];
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: sheetBg,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (context, setSheetState) {
+            return Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(
+                      width: 44,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: secondaryText.withValues(alpha: 0.28),
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  Text(
+                    'Report a discrepancy',
                     style: TextStyle(
-                      fontSize: 17,
-                      fontWeight: FontWeight.w700,
-                      color: AppColors.textPrimary,
+                      color: primaryText,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w900,
                     ),
                   ),
                   const SizedBox(height: 8),
-                  Expanded(
-                    child: ListView(
-                      padding: EdgeInsets.zero,
-                      children: [
-                        _accountOption(
-                          icon: Icons.person_outline,
-                          title: 'Profile details',
-                          onTap: () {
-                            Navigator.pop(sheetContext);
-                            _openProfile(context);
-                          },
+                  Text(
+                    'Pick one reason. No typing needed. We will log the report and follow up within 24 hours.',
+                    style: TextStyle(color: secondaryText, height: 1.35),
+                  ),
+                  const SizedBox(height: 16),
+                  Wrap(
+                    spacing: 10,
+                    runSpacing: 10,
+                    children: options.map((label) {
+                      final isSelected = selectedReason == label;
+                      return ChoiceChip(
+                        label: Text(label),
+                        selected: isSelected,
+                        onSelected: (_) =>
+                            setSheetState(() => selectedReason = label),
+                        selectedColor: AppColors.neonGreen.withValues(
+                          alpha: 0.18,
                         ),
-                        _accountOption(
-                          icon: Icons.description_outlined,
-                          title: 'Policy details',
-                          onTap: () {
-                            Navigator.pop(sheetContext);
-                            _openCoverage(context);
-                          },
+                        backgroundColor: chipBg,
+                        labelStyle: TextStyle(
+                          color: isSelected ? primaryText : secondaryText,
+                          fontWeight: FontWeight.w700,
                         ),
-                        _accountOption(
-                          icon: Icons.receipt_long_outlined,
-                          title: 'Claims and disputes',
-                          onTap: () {
-                            Navigator.pop(sheetContext);
-                            _openClaims(context);
-                          },
-                        ),
-                        _accountOption(
-                          icon: Icons.payments_outlined,
-                          title: 'Plan and pricing',
-                          onTap: () {
-                            Navigator.pop(sheetContext);
-                            _openCoverage(context);
-                          },
-                        ),
-                        _accountOption(
-                          icon: Icons.payments_outlined,
-                          title: 'Payouts ledger',
-                          onTap: () {
-                            Navigator.pop(sheetContext);
-                            _openPayouts(context);
-                          },
-                        ),
-                        _accountOption(
-                          icon: Icons.help_outline,
-                          title: 'Help and support',
-                          onTap: () {
-                            Navigator.pop(sheetContext);
-                            _showSupportSheet(context);
-                          },
-                        ),
-                        _accountOption(
-                          icon: Icons.language,
-                          title: 'Language',
-                          onTap: () {
-                            Navigator.pop(sheetContext);
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content:
-                                    Text('Language settings will be added next.'),
-                              ),
-                            );
-                          },
-                        ),
-                        _accountOption(
-                          icon: Icons.logout,
-                          title: 'Log out',
-                          isDestructive: true,
-                          onTap: () {
-                            Navigator.pop(sheetContext);
-                            Navigator.pushNamedAndRemoveUntil(
-                              context,
-                              AppRoutes.welcome,
-                              (route) => false,
-                            );
-                          },
-                        ),
-                      ],
+                      );
+                    }).toList(),
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: selectedReason == null
+                          ? null
+                          : () {
+                              Navigator.of(sheetContext).pop();
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text(
+                                    'Report logged: $selectedReason. Cross-checking within 24 hours.',
+                                  ),
+                                ),
+                              );
+                            },
+                      child: const Text('Submit report'),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  void _downloadReceipt(BuildContext context, String reference, double amount) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          'Receipt queued: $reference · ${_currency.format(amount)}',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showChaChingModal(
+    BuildContext context,
+    double amount,
+    String reference,
+    String upiId,
+  ) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final dialogBg = isDark
+        ? AppColors.nightBackground
+        : theme.colorScheme.surface;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.68 : 0.78,
+    );
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      builder: (dialogContext) {
+        return Dialog.fullscreen(
+          backgroundColor: dialogBg,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(22, 18, 22, 28),
+              child: Column(
+                children: [
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: IconButton(
+                      onPressed: () => Navigator.of(dialogContext).pop(),
+                      icon: const Icon(
+                        Icons.close_rounded,
+                        color: AppColors.neonGreen,
+                      ),
+                    ),
+                  ),
+                  const Spacer(),
+                  Container(
+                    width: 118,
+                    height: 118,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: AppColors.neonGreen.withValues(alpha: 0.18),
+                      border: Border.all(
+                        color: AppColors.neonGreen.withValues(alpha: 0.4),
+                      ),
+                    ),
+                    child: const Icon(
+                      Icons.check_rounded,
+                      size: 72,
+                      color: AppColors.neonGreen,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  const Text(
+                    'CHA-CHING!',
+                    style: TextStyle(
+                      color: AppColors.neonGreen,
+                      fontSize: 34,
+                      fontWeight: FontWeight.w900,
+                      letterSpacing: 1.2,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    _currency.format(amount),
+                    style: TextStyle(
+                      color: primaryText,
+                      fontSize: 44,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    'Sent to $upiId',
+                    style: TextStyle(color: secondaryText, fontSize: 14),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    'Ref $reference',
+                    style: TextStyle(
+                      color: secondaryText.withValues(alpha: 0.82),
+                      fontSize: 12,
+                      fontFamily: 'monospace',
+                    ),
+                  ),
+                  const Spacer(),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton.icon(
+                      onPressed: () {
+                        Navigator.of(dialogContext).pop();
+                        _downloadReceipt(context, reference, amount);
+                      },
+                      icon: const Icon(Icons.download_rounded),
+                      label: const Text('Download Receipt'),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton(
+                      onPressed: () => Navigator.of(dialogContext).pop(),
+                      child: const Text('Back to Dashboard'),
                     ),
                   ),
                 ],
@@ -2066,161 +2133,767 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  Widget _accountOption({
-    required IconData icon,
-    required String title,
-    required VoidCallback onTap,
-    bool isDestructive = false,
-  }) {
-    final textColor =
-        isDestructive ? AppColors.error : AppColors.textPrimary;
+  Color _riskTone(double score) {
+    if (score >= 80) return AppColors.neonRed;
+    if (score >= 60) return AppColors.neonAmber;
+    if (score >= 40) return AppColors.neonCyan;
+    return AppColors.neonGreen;
+  }
 
-    return ListTile(
-      onTap: onTap,
-      contentPadding: const EdgeInsets.symmetric(vertical: 2),
-      leading: Icon(icon, color: textColor, size: 25),
-      title: Text(
-        title,
-        style: TextStyle(
-          fontSize: 17,
-          fontWeight: FontWeight.w500,
-          color: textColor,
-        ),
+  void _showVerificationSheet(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final sheetBg = isDark ? AppColors.nightSurface : theme.colorScheme.surface;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.68 : 0.78,
+    );
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: sheetBg,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
       ),
-      trailing: Icon(
-        Icons.chevron_right,
-        color:
-            isDestructive ? AppColors.error : AppColors.textSecondary,
-      ),
+      builder: (sheetContext) {
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 44,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: secondaryText.withValues(alpha: 0.28),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
+              Text(
+                'Security verification',
+                style: TextStyle(
+                  color: primaryText,
+                  fontSize: 20,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'This protects your payout if location data looks unusual.',
+                style: TextStyle(color: secondaryText, height: 1.35),
+              ),
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: isDark
+                      ? AppColors.nightSurfaceElevated
+                      : theme.colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(18),
+                  border: Border.all(
+                    color: AppColors.neonGreen.withValues(alpha: 0.22),
+                  ),
+                ),
+                child: const Column(
+                  children: [
+                    _StepperRow(label: 'Trigger met', done: true),
+                    SizedBox(height: 10),
+                    _StepperRow(label: 'Verification processing', done: false),
+                    SizedBox(height: 10),
+                    _StepperRow(label: 'Payout initiated', done: false),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(sheetContext).pop();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text(
+                          'Live location request started for 5 minutes.',
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Share live location for 5 minutes'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 
-  // ignore: unused_element
-  Widget _headerIconButton({
-    required IconData icon,
-    required String tooltip,
-    required VoidCallback onTap,
-  }) {
-    return Tooltip(
-      message: tooltip,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: onTap,
-        child: Container(
-          width: 42,
-          height: 42,
-          decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.2),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: Colors.white.withValues(alpha: 0.28),
+  Widget _readingRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        children: [
+          Text(
+            label,
+            style: TextStyle(color: Colors.white.withValues(alpha: 0.68)),
+          ),
+          const Spacer(),
+          Text(
+            value,
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.w800,
             ),
           ),
-          child: Icon(icon, size: 21, color: AppColors.textPrimary),
-        ),
+        ],
       ),
+    );
+  }
+
+  _RiskMetricState _metricState(
+    String key,
+    String activeType,
+    double current,
+    double threshold,
+  ) {
+    if (activeType.contains(key)) {
+      return current >= threshold
+          ? _RiskMetricState.critical
+          : _RiskMetricState.alert;
+    }
+    final ratio = threshold <= 0 ? 0.0 : current / threshold;
+    if (ratio >= 1.0) return _RiskMetricState.critical;
+    if (ratio >= 0.8) return _RiskMetricState.alert;
+    if (ratio >= 0.65) return _RiskMetricState.watch;
+    return _RiskMetricState.safe;
+  }
+
+  double _metricCurrent(
+    Map<String, dynamic> source,
+    List<String> keys, {
+    required double fallback,
+  }) {
+    for (final key in keys) {
+      final value = source[key];
+      if (value is num) return value.toDouble();
+      if (value is String) {
+        final parsed = double.tryParse(value.replaceAll(',', '').trim());
+        if (parsed != null) return parsed;
+      }
+    }
+    return fallback;
+  }
+
+  String _metricLabel(double value, String unit) {
+    if (unit == 'AQI' || unit == 'score') {
+      return value.toStringAsFixed(0);
+    }
+    return value.truncateToDouble() == value
+        ? value.toStringAsFixed(0)
+        : value.toStringAsFixed(1);
+  }
+
+  String _formatShortDate(DateTime value) =>
+      DateFormat('d MMM').format(value.toLocal());
+
+  String _formatDateTime(DateTime value) =>
+      DateFormat('d MMM, h:mm a').format(value.toLocal());
+
+  Color _statusColor(ClaimStatus status) {
+    return switch (status) {
+      ClaimStatus.pending => AppColors.neonAmber,
+      ClaimStatus.inReview => AppColors.neonCyan,
+      ClaimStatus.escalated => AppColors.neonPurple,
+      ClaimStatus.settled => AppColors.neonGreen,
+      ClaimStatus.rejected => AppColors.neonRed,
+    };
+  }
+
+  String _zoneLabel(User user, Map<String, dynamic> policy, String zoneKey) {
+    final zone = _coerceString(
+      user.zone,
+      fallback: _coerceString(policy['zone']),
+    );
+    if (zone.isNotEmpty) return zone;
+    if (zoneKey.isNotEmpty) return zoneKey;
+    return 'Zone not set';
+  }
+
+  String _shortName(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return 'Rider';
+    final first = trimmed.split(RegExp(r'\s+')).first;
+    return first.length > 12 ? first.substring(0, 12) : first;
+  }
+
+  String _coerceString(Object? value, {String fallback = ''}) {
+    final parsed = value?.toString().trim() ?? '';
+    return parsed.isEmpty ? fallback : parsed;
+  }
+
+  int _coerceInt(Object? value, {required int fallback}) {
+    if (value is num) return value.toInt();
+    if (value is String) {
+      final parsed = int.tryParse(value.replaceAll(',', '').trim());
+      if (parsed != null) return parsed;
+    }
+    return fallback;
+  }
+
+  double _coerceDouble(Object? value, {required double fallback}) {
+    if (value is num) return value.toDouble();
+    if (value is String) {
+      final parsed = double.tryParse(value.replaceAll(',', '').trim());
+      if (parsed != null) return parsed;
+    }
+    return fallback;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<_DashboardData>(
+      future: _dashboardFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(
+            backgroundColor: AppColors.nightBackground,
+            body: Center(
+              child: CircularProgressIndicator(color: AppColors.neonGreen),
+            ),
+          );
+        }
+
+        if (snapshot.hasError || snapshot.data == null) {
+          return Scaffold(
+            backgroundColor: AppColors.nightBackground,
+            body: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Failed to load the rider dashboard. Pull to retry after checking the session.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Colors.white.withValues(alpha: 0.72)),
+                ),
+              ),
+            ),
+          );
+        }
+
+        return _buildBody(context, snapshot.data!);
+      },
     );
   }
 }
 
-// ─── Background painter ────────────────────────────────────────────────────
-
-class _HomeTopBackgroundPainter extends CustomPainter {
-  const _HomeTopBackgroundPainter({required this.topHeight});
-
-  final double topHeight;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final backgroundPath = Path()
-      ..moveTo(0, 0)
-      ..lineTo(0, topHeight - 18)
-      ..cubicTo(
-        size.width * 0.12,
-        topHeight + 8,
-        size.width * 0.28,
-        topHeight - 28,
-        size.width * 0.44,
-        topHeight - 4,
-      )
-      ..cubicTo(
-        size.width * 0.60,
-        topHeight + 18,
-        size.width * 0.78,
-        topHeight + 2,
-        size.width,
-        topHeight - 16,
-      )
-      ..lineTo(size.width, 0)
-      ..close();
-
-    final paint = Paint()
-      ..shader = const LinearGradient(
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
-        colors: [
-          Color(0xFFF9FAF7),
-          Color(0xFFF2F6F2),
-          Color(0xFFEAF2EE),
-        ],
-      ).createShader(
-        Rect.fromLTWH(0, 0, size.width, topHeight + 40),
-      );
-
-    canvas.drawPath(backgroundPath, paint);
-
-    final accentPaint = Paint()
-      ..color = AppColors.primary.withValues(alpha: 0.08)
-      ..style = PaintingStyle.fill;
-
-    canvas.drawCircle(Offset(size.width * 0.1, size.height * 0.18), 56, accentPaint);
-    canvas.drawCircle(Offset(size.width * 0.86, size.height * 0.26), 36, accentPaint);
-  }
-
-  @override
-  bool shouldRepaint(covariant _HomeTopBackgroundPainter oldDelegate) {
-    return oldDelegate.topHeight != topHeight;
-  }
-}
-
-// ─── View data model ───────────────────────────────────────────────────────
-
-class _HomeViewData {
-  const _HomeViewData({
+class _DashboardData {
+  const _DashboardData({
     required this.user,
+    required this.plan,
+    required this.policy,
+    required this.payoutDashboard,
+    required this.activeTriggers,
     required this.claims,
+    required this.zoneRisk,
+    required this.metrics,
+    required this.forecast,
+    required this.status,
+    required this.heroMetric,
     required this.latestClaim,
-    required this.autoTriggerMessages,
-    required this.activePlan,
-    required this.earningsProtected,
-    required this.totalEarnings,
-    required this.coveredDaysLeft,
-    required this.cycleStartDate,
-    required this.cycleEndDate,
-    required this.pendingEffectiveDate,
-    required this.isScheduled,
-    required this.policyStatus,
-    required this.zoneLabel,
-    required this.platformLabel,
-    required this.claimsProcessedThisWeek,
-    required this.payoutThisWeek,
+    required this.latestSettledClaim,
+    required this.upiId,
+    required this.safetyBanner,
+    required this.safetyDetail,
+    required this.premiumBreakdown,
+    required this.nearMiss,
+    required this.payoutVault,
   });
 
   final User user;
+  final InsurancePlan plan;
+  final Map<String, dynamic> policy;
+  final Map<String, dynamic> payoutDashboard;
+  final Map<String, dynamic> activeTriggers;
   final List<Claim> claims;
-  final Claim? latestClaim;
-  final List<String> autoTriggerMessages;
-  final InsurancePlan activePlan;
-  final double earningsProtected;
-  final double? totalEarnings;
-  final int coveredDaysLeft;
-  final String cycleStartDate;
-  final String cycleEndDate;
-  final String pendingEffectiveDate;
-  final bool isScheduled;
-  final String policyStatus;
-  final String zoneLabel;
-  final String platformLabel;
-  final int claimsProcessedThisWeek;
-  final double payoutThisWeek;
+  final ZoneRisk? zoneRisk;
+  final List<_RiskMetric> metrics;
+  final List<_ForecastBlock> forecast;
+  final _RiskStatus status;
+  final _RiskMetric? heroMetric;
+  final _ClaimSnapshot? latestClaim;
+  final _ClaimSnapshot? latestSettledClaim;
+  final String upiId;
+  final String safetyBanner;
+  final String safetyDetail;
+  final List<_AllocationSlice> premiumBreakdown;
+  final _NearMissSignal nearMiss;
+  final _PayoutVault payoutVault;
+}
+
+class _NearMissSignal {
+  const _NearMissSignal({
+    required this.metric,
+    required this.monitoringMinutes,
+  });
+
+  final _RiskMetric metric;
+  final int monitoringMinutes;
+}
+
+class _PayoutVault {
+  const _PayoutVault({
+    required this.securedAmount,
+    required this.potentialAmount,
+    required this.securedRatio,
+  });
+
+  final double securedAmount;
+  final double potentialAmount;
+  final double securedRatio;
+}
+
+class _RadarPoint {
+  const _RadarPoint({required this.label, required this.value});
+
+  final String label;
+  final double value;
+}
+
+class _ClaimSnapshot {
+  const _ClaimSnapshot({
+    required this.id,
+    required this.amount,
+    required this.date,
+    required this.typeLabel,
+  });
+
+  factory _ClaimSnapshot.fromClaim(Claim claim) {
+    return _ClaimSnapshot(
+      id: claim.id,
+      amount: claim.amount,
+      date: claim.date,
+      typeLabel: claim.typeName,
+    );
+  }
+
+  final String id;
+  final double amount;
+  final DateTime date;
+  final String typeLabel;
+}
+
+class _RiskMetric {
+  const _RiskMetric({
+    required this.key,
+    required this.label,
+    required this.icon,
+    required this.current,
+    required this.threshold,
+    required this.unit,
+    required this.detail,
+    required this.state,
+  });
+
+  final String key;
+  final String label;
+  final IconData icon;
+  final double current;
+  final double threshold;
+  final String unit;
+  final String detail;
+  final _RiskMetricState state;
+
+  double get ratio {
+    if (threshold <= 0) return 0;
+    return (current / threshold).clamp(0, 1.5).toDouble();
+  }
+
+  String get displayValue => '${_formatNumber(current)} $unit';
+  String get thresholdDisplay => '${_formatNumber(threshold)} $unit';
+  String get gapDisplay {
+    final gap = (threshold - current).abs();
+    return current >= threshold
+        ? 'Crossed by ${_formatNumber(gap)} $unit'
+        : 'Needs ${_formatNumber(gap)} $unit';
+  }
+
+  Color get color {
+    return switch (state) {
+      _RiskMetricState.safe => AppColors.neonGreen,
+      _RiskMetricState.watch => AppColors.neonAmber,
+      _RiskMetricState.alert => AppColors.neonRed,
+      _RiskMetricState.critical => AppColors.neonPurple,
+    };
+  }
+
+  static String _formatNumber(double value) {
+    return value.truncateToDouble() == value
+        ? value.toStringAsFixed(0)
+        : value.toStringAsFixed(1);
+  }
+}
+
+enum _RiskMetricState { safe, watch, alert, critical }
+
+enum _RiskLevel { safe, watch, alert, critical }
+
+extension _RiskLevelLabel on _RiskLevel {
+  String get label {
+    return switch (this) {
+      _RiskLevel.safe => 'SAFE',
+      _RiskLevel.watch => 'WATCH',
+      _RiskLevel.alert => 'ALERT',
+      _RiskLevel.critical => 'CRITICAL',
+    };
+  }
+}
+
+class _RiskStatus {
+  const _RiskStatus({
+    required this.level,
+    required this.label,
+    required this.summary,
+  });
+
+  final _RiskLevel level;
+  final String label;
+  final String summary;
+
+  Color get color {
+    return switch (level) {
+      _RiskLevel.safe => AppColors.neonGreen,
+      _RiskLevel.watch => AppColors.neonAmber,
+      _RiskLevel.alert => AppColors.neonRed,
+      _RiskLevel.critical => AppColors.neonPurple,
+    };
+  }
+}
+
+class _ForecastBlock {
+  const _ForecastBlock({
+    required this.label,
+    required this.color,
+    required this.caption,
+    required this.shimmer,
+  });
+
+  final String label;
+  final Color color;
+  final String caption;
+  final Color shimmer;
+}
+
+class _AllocationSlice {
+  const _AllocationSlice({
+    required this.label,
+    required this.share,
+    required this.color,
+  });
+
+  final String label;
+  final int share;
+  final Color color;
+}
+
+class _QuickActionButton extends StatelessWidget {
+  const _QuickActionButton({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bgColor = isDark
+        ? AppColors.nightSurface
+        : Theme.of(context).colorScheme.surface;
+    final borderColor = isDark
+        ? color.withValues(alpha: 0.22)
+        : color.withValues(alpha: 0.34);
+    final textColor = Theme.of(context).colorScheme.onSurface;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: bgColor,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: borderColor),
+          ),
+          child: Column(
+            children: [
+              Icon(icon, color: color, size: 24),
+              const SizedBox(height: 8),
+              Text(
+                label,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: textColor,
+                  fontWeight: FontWeight.w800,
+                  fontSize: 12,
+                  height: 1.2,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StepperRow extends StatelessWidget {
+  const _StepperRow({required this.label, required this.done});
+
+  final String label;
+  final bool done;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = done
+        ? AppColors.neonGreen
+        : Colors.white.withValues(alpha: 0.45);
+    return Row(
+      children: [
+        Container(
+          width: 16,
+          height: 16,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          child: done
+              ? const Icon(Icons.check_rounded, color: Colors.black, size: 12)
+              : null,
+        ),
+        const SizedBox(width: 10),
+        Text(
+          label,
+          style: TextStyle(color: color, fontWeight: FontWeight.w700),
+        ),
+      ],
+    );
+  }
+}
+
+class _RiskHexagonCard extends StatelessWidget {
+  const _RiskHexagonCard({
+    required this.title,
+    required this.summary,
+    required this.metricLabel,
+    required this.metricValue,
+    required this.metricUnit,
+    required this.color,
+    required this.onTap,
+  });
+
+  final String title;
+  final String summary;
+  final String metricLabel;
+  final String metricValue;
+  final String metricUnit;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final cardBg = isDark ? AppColors.nightSurface : theme.colorScheme.surface;
+    final cardBorder = isDark
+        ? color.withValues(alpha: 0.22)
+        : color.withValues(alpha: 0.18);
+    final titleColor = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.75 : 0.78,
+    );
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.70 : 0.76,
+    );
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(32),
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: cardBg,
+            borderRadius: BorderRadius.circular(32),
+            border: Border.all(color: cardBorder),
+          ),
+          child: Column(
+            children: [
+              ClipPath(
+                clipper: _HexagonClipper(),
+                child: Container(
+                  height: 220,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        color.withValues(alpha: 0.20),
+                        isDark
+                            ? AppColors.nightSurfaceElevated
+                            : theme.colorScheme.surfaceContainerHighest,
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                  ),
+                  child: Stack(
+                    children: [
+                      Positioned.fill(
+                        child: CustomPaint(painter: _GlowPainter(color)),
+                      ),
+                      Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              title,
+                              style: TextStyle(
+                                color: titleColor,
+                                fontSize: 12,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 1.1,
+                              ),
+                            ),
+                            const SizedBox(height: 10),
+                            Text(
+                              metricValue,
+                              style: TextStyle(
+                                color: primaryText,
+                                fontSize: 52,
+                                fontWeight: FontWeight.w900,
+                                letterSpacing: -1.2,
+                              ),
+                            ),
+                            if (metricUnit.isNotEmpty)
+                              Text(
+                                metricUnit,
+                                style: TextStyle(
+                                  color: secondaryText,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                            const SizedBox(height: 8),
+                            Text(
+                              metricLabel,
+                              style: TextStyle(
+                                color: color,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                summary,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: secondaryText,
+                  fontSize: 12,
+                  height: 1.35,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HexagonClipper extends CustomClipper<Path> {
+  @override
+  Path getClip(Size size) {
+    final path = Path();
+    final width = size.width;
+    final height = size.height;
+    path.moveTo(width * 0.25, 0);
+    path.lineTo(width * 0.75, 0);
+    path.lineTo(width, height * 0.5);
+    path.lineTo(width * 0.75, height);
+    path.lineTo(width * 0.25, height);
+    path.lineTo(0, height * 0.5);
+    path.close();
+    return path;
+  }
+
+  @override
+  bool shouldReclip(covariant CustomClipper<Path> oldClipper) => false;
+}
+
+class _GlowPainter extends CustomPainter {
+  const _GlowPainter(this.color);
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..shader =
+          RadialGradient(
+            colors: [color.withValues(alpha: 0.55), Colors.transparent],
+          ).createShader(
+            Rect.fromCircle(
+              center: Offset(size.width * 0.5, size.height * 0.5),
+              radius: size.shortestSide * 0.55,
+            ),
+          );
+    canvas.drawCircle(
+      Offset(size.width * 0.5, size.height * 0.5),
+      size.shortestSide * 0.42,
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _GlowPainter oldDelegate) =>
+      oldDelegate.color != color;
+}
+
+class _AllocationDonutPainter extends CustomPainter {
+  _AllocationDonutPainter(this.slices);
+
+  final List<_AllocationSlice> slices;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    final stroke = math.max(14.0, size.shortestSide * 0.14);
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = stroke
+      ..strokeCap = StrokeCap.round;
+    double start = -math.pi / 2;
+    const sweepBase = 2 * math.pi;
+    for (final slice in slices) {
+      paint.color = slice.color;
+      final sweep = sweepBase * (slice.share / 100);
+      canvas.drawArc(rect.deflate(stroke / 2), start, sweep, false, paint);
+      start += sweep;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _AllocationDonutPainter oldDelegate) =>
+      oldDelegate.slices != slices;
 }

--- a/lib/screens/onboarding/onboarding_screen.dart
+++ b/lib/screens/onboarding/onboarding_screen.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../routes/app_routes.dart';
 
 class OnboardingScreen extends StatefulWidget {
@@ -11,6 +14,9 @@ class OnboardingScreen extends StatefulWidget {
 
 class _OnboardingScreenState extends State<OnboardingScreen> {
   int _currentPage = 0;
+  bool _isRedirecting = false;
+
+  static const String _onboardingSeenKey = 'product_onboarding_seen';
 
   static const List<_OnboardingSlide> _slides = [
     _OnboardingSlide(
@@ -48,7 +54,29 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     ),
   ];
 
-  void _finishOnboarding(BuildContext context) {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _maybeSkipOnboarding();
+    });
+  }
+
+  Future<void> _maybeSkipOnboarding() async {
+    if (_isRedirecting || !mounted) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final seen = prefs.getBool(_onboardingSeenKey) ?? false;
+    if (!seen || !mounted) return;
+
+    _isRedirecting = true;
+    Navigator.pushReplacementNamed(context, AppRoutes.bootstrap);
+  }
+
+  Future<void> _finishOnboarding(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_onboardingSeenKey, true);
+    if (!mounted) return;
     Navigator.pushReplacementNamed(context, AppRoutes.bootstrap);
   }
 
@@ -59,7 +87,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       });
       return;
     }
-    _finishOnboarding(context);
+    unawaited(_finishOnboarding(context));
   }
 
   void _onPrevPressed() {
@@ -92,292 +120,309 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 constraints: BoxConstraints(minHeight: constraints.maxHeight),
                 child: IntrinsicHeight(
                   child: Padding(
-                    padding: EdgeInsets.fromLTRB(22, 28 * scale, 22, 22 * scale),
+                    padding: EdgeInsets.fromLTRB(
+                      22,
+                      28 * scale,
+                      22,
+                      22 * scale,
+                    ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                  // Top header with page dots and skip button
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      // Page dots
-                      Row(
-                        children: [
-                          for (int i = 0; i < _slides.length; i++) ...[
-                            Container(
-                              width: (_currentPage == i ? 20 : 6) * scale,
-                              height: 5 * scale,
-                              decoration: BoxDecoration(
-                                color: _currentPage == i
-                                    ? const Color(0xFF14B890)
-                                    : const Color(0xFFD0D5DD),
-                                borderRadius: BorderRadius.circular(3),
-                              ),
-                            ),
-                            if (i != _slides.length - 1)
-                              SizedBox(width: 6 * scale),
-                          ],
-                        ],
-                      ),
-                      if (_currentPage < _slides.length - 1)
-                        GestureDetector(
-                          onTap: () => _finishOnboarding(context),
-                          child: Container(
-                            padding: EdgeInsets.symmetric(
-                              horizontal: 14 * scale,
-                              vertical: 7 * scale,
-                            ),
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              borderRadius: BorderRadius.circular(12 * scale),
-                              border:
-                                  Border.all(color: const Color(0xFFE9ECEF)),
-                            ),
-                            child: Text(
-                              'Skip',
-                              style: GoogleFonts.inter(
-                                fontSize: 13 * scale,
-                                fontWeight: FontWeight.w700,
-                                color: const Color(0xFF4F5660),
-                              ),
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-
-                  SizedBox(height: 50 * scale),
-
-                  // Heading
-                  Align(
-                    alignment: Alignment.center,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        SizedBox(
-                          width: double.infinity,
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            child: Text(
-                              slide.titleLine1,
-                              textAlign: TextAlign.center,
-                              style: GoogleFonts.inter(
-                                fontSize: 42 * headingScale,
-                                fontWeight: FontWeight.w500,
-                                height: 1.0,
-                                letterSpacing: -1.2,
-                                color: const Color(0xFF171717),
-                              ),
-                            ),
-                          ),
-                        ),
-                        SizedBox(
-                          width: double.infinity,
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            child: Text(
-                              slide.titleLine2,
-                              textAlign: TextAlign.center,
-                              style: GoogleFonts.pacifico(
-                                fontSize: 52 * headingScale,
-                                fontWeight: FontWeight.w400,
-                                height: 1.05,
-                                color: const Color(0xFF14B890),
-                              ),
-                            ),
-                          ),
-                        ),
-                        SizedBox(height: 10 * scale),
-                        SizedBox(
-                          width: double.infinity,
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            child: Text(
-                              slide.titleLine3,
-                              textAlign: TextAlign.center,
-                              style: GoogleFonts.inter(
-                                fontSize: 42 * headingScale,
-                                fontWeight: FontWeight.w500,
-                                height: 1.0,
-                                letterSpacing: -1.2,
-                                color: const Color(0xFF171717),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-
-                  SizedBox(height: 16 * scale),
-
-                  // Illustration area
-                  Container(
-                    width: double.infinity,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(20 * scale),
-                    ),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(18 * scale),
-                      child: SizedBox(
-                        height: 300 * scale,
-                        width: double.infinity,
-                        child: Image.asset(
-                          slide.imagePath,
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) {
-                            return Container(
-                              alignment: Alignment.center,
-                              color: Colors.white,
-                              child: Text(
-                                'Image not found',
-                                style: GoogleFonts.inter(
-                                  fontSize: 14 * scale,
-                                  color: const Color(0xFF5C6169),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                    ),
-                  ),
-
-                  SizedBox(height: 16 * scale),
-
-                  // Description
-                  Text(
-                    slide.description,
-                    style: GoogleFonts.inter(
-                      fontSize: 13 * scale,
-                      fontWeight: FontWeight.w400,
-                      height: 1.55,
-                      color: const Color(0xFF5C6169),
-                    ),
-                  ),
-
-                  SizedBox(height: 20 * scale),
-
-                  // Feature rows
-                  _FeatureRow(
-                    icon: Icons.access_time_rounded,
-                    label: slide.feature1,
-                    scale: scale,
-                  ),
-                  SizedBox(height: 13 * scale),
-                  _FeatureRow(
-                    icon: Icons.credit_card_rounded,
-                    label: slide.feature2,
-                    scale: scale,
-                  ),
-                  SizedBox(height: 13 * scale),
-                  _FeatureRow(
-                    icon: Icons.star_border_rounded,
-                    label: slide.feature3,
-                    scale: scale,
-                  ),
-
-                  const Spacer(),
-
-                  if (_currentPage == _slides.length - 1)
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        GestureDetector(
-                          onTap: () => _finishOnboarding(context),
-                          child: Container(
-                            width: double.infinity,
-                            constraints: BoxConstraints(maxWidth: 320 * scale),
-                            padding: EdgeInsets.symmetric(
-                              vertical: 16 * scale,
-                            ),
-                            decoration: BoxDecoration(
-                              color: const Color(0xFF14B890),
-                              borderRadius: BorderRadius.circular(18 * scale),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: const Color(0xFF14B890)
-                                      .withOpacity(0.28),
-                                  blurRadius: 18 * scale,
-                                  offset: Offset(0, 8 * scale),
-                                ),
+                        // Top header with page dots and skip button
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            // Page dots
+                            Row(
+                              children: [
+                                for (int i = 0; i < _slides.length; i++) ...[
+                                  Container(
+                                    width: (_currentPage == i ? 20 : 6) * scale,
+                                    height: 5 * scale,
+                                    decoration: BoxDecoration(
+                                      color: _currentPage == i
+                                          ? const Color(0xFF14B890)
+                                          : const Color(0xFFD0D5DD),
+                                      borderRadius: BorderRadius.circular(3),
+                                    ),
+                                  ),
+                                  if (i != _slides.length - 1)
+                                    SizedBox(width: 6 * scale),
+                                ],
                               ],
                             ),
-                            alignment: Alignment.center,
-                            child: Text(
-                              'Get Started',
-                              style: GoogleFonts.inter(
-                                fontSize: 16 * scale,
-                                fontWeight: FontWeight.w700,
-                                color: Colors.white,
+                            if (_currentPage < _slides.length - 1)
+                              GestureDetector(
+                                onTap: () =>
+                                    unawaited(_finishOnboarding(context)),
+                                child: Container(
+                                  padding: EdgeInsets.symmetric(
+                                    horizontal: 14 * scale,
+                                    vertical: 7 * scale,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: Colors.white,
+                                    borderRadius: BorderRadius.circular(
+                                      12 * scale,
+                                    ),
+                                    border: Border.all(
+                                      color: const Color(0xFFE9ECEF),
+                                    ),
+                                  ),
+                                  child: Text(
+                                    'Skip',
+                                    style: GoogleFonts.inter(
+                                      fontSize: 13 * scale,
+                                      fontWeight: FontWeight.w700,
+                                      color: const Color(0xFF4F5660),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+
+                        SizedBox(height: 50 * scale),
+
+                        // Heading
+                        Align(
+                          alignment: Alignment.center,
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              SizedBox(
+                                width: double.infinity,
+                                child: FittedBox(
+                                  fit: BoxFit.scaleDown,
+                                  child: Text(
+                                    slide.titleLine1,
+                                    textAlign: TextAlign.center,
+                                    style: GoogleFonts.inter(
+                                      fontSize: 42 * headingScale,
+                                      fontWeight: FontWeight.w500,
+                                      height: 1.0,
+                                      letterSpacing: -1.2,
+                                      color: const Color(0xFF171717),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              SizedBox(
+                                width: double.infinity,
+                                child: FittedBox(
+                                  fit: BoxFit.scaleDown,
+                                  child: Text(
+                                    slide.titleLine2,
+                                    textAlign: TextAlign.center,
+                                    style: GoogleFonts.pacifico(
+                                      fontSize: 52 * headingScale,
+                                      fontWeight: FontWeight.w400,
+                                      height: 1.05,
+                                      color: const Color(0xFF14B890),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              SizedBox(height: 10 * scale),
+                              SizedBox(
+                                width: double.infinity,
+                                child: FittedBox(
+                                  fit: BoxFit.scaleDown,
+                                  child: Text(
+                                    slide.titleLine3,
+                                    textAlign: TextAlign.center,
+                                    style: GoogleFonts.inter(
+                                      fontSize: 42 * headingScale,
+                                      fontWeight: FontWeight.w500,
+                                      height: 1.0,
+                                      letterSpacing: -1.2,
+                                      color: const Color(0xFF171717),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+
+                        SizedBox(height: 16 * scale),
+
+                        // Illustration area
+                        Container(
+                          width: double.infinity,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(20 * scale),
+                          ),
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(18 * scale),
+                            child: SizedBox(
+                              height: 300 * scale,
+                              width: double.infinity,
+                              child: Image.asset(
+                                slide.imagePath,
+                                fit: BoxFit.cover,
+                                errorBuilder: (context, error, stackTrace) {
+                                  return Container(
+                                    alignment: Alignment.center,
+                                    color: Colors.white,
+                                    child: Text(
+                                      'Image not found',
+                                      style: GoogleFonts.inter(
+                                        fontSize: 14 * scale,
+                                        color: const Color(0xFF5C6169),
+                                      ),
+                                    ),
+                                  );
+                                },
                               ),
                             ),
                           ),
                         ),
-                      ],
-                    )
-                  else
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        // Left arrow button
-                        GestureDetector(
-                          onTap: _onPrevPressed,
-                          child: Container(
-                            width: 54 * scale,
-                            height: 54 * scale,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: _currentPage > 0
-                                  ? const Color(0xFF14B890)
-                                  : const Color(0xFFD0D5DD),
-                              boxShadow: _currentPage > 0
-                                  ? [
+
+                        SizedBox(height: 16 * scale),
+
+                        // Description
+                        Text(
+                          slide.description,
+                          style: GoogleFonts.inter(
+                            fontSize: 13 * scale,
+                            fontWeight: FontWeight.w400,
+                            height: 1.55,
+                            color: const Color(0xFF5C6169),
+                          ),
+                        ),
+
+                        SizedBox(height: 20 * scale),
+
+                        // Feature rows
+                        _FeatureRow(
+                          icon: Icons.access_time_rounded,
+                          label: slide.feature1,
+                          scale: scale,
+                        ),
+                        SizedBox(height: 13 * scale),
+                        _FeatureRow(
+                          icon: Icons.credit_card_rounded,
+                          label: slide.feature2,
+                          scale: scale,
+                        ),
+                        SizedBox(height: 13 * scale),
+                        _FeatureRow(
+                          icon: Icons.star_border_rounded,
+                          label: slide.feature3,
+                          scale: scale,
+                        ),
+
+                        const Spacer(),
+
+                        if (_currentPage == _slides.length - 1)
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              GestureDetector(
+                                onTap: () =>
+                                    unawaited(_finishOnboarding(context)),
+                                child: Container(
+                                  width: double.infinity,
+                                  constraints: BoxConstraints(
+                                    maxWidth: 320 * scale,
+                                  ),
+                                  padding: EdgeInsets.symmetric(
+                                    vertical: 16 * scale,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: const Color(0xFF14B890),
+                                    borderRadius: BorderRadius.circular(
+                                      18 * scale,
+                                    ),
+                                    boxShadow: [
                                       BoxShadow(
-                                        color: const Color(0xFF14B890)
-                                            .withOpacity(0.35),
+                                        color: const Color(
+                                          0xFF14B890,
+                                        ).withOpacity(0.28),
+                                        blurRadius: 18 * scale,
+                                        offset: Offset(0, 8 * scale),
+                                      ),
+                                    ],
+                                  ),
+                                  alignment: Alignment.center,
+                                  child: Text(
+                                    'Get Started',
+                                    style: GoogleFonts.inter(
+                                      fontSize: 16 * scale,
+                                      fontWeight: FontWeight.w700,
+                                      color: Colors.white,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          )
+                        else
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              // Left arrow button
+                              GestureDetector(
+                                onTap: _onPrevPressed,
+                                child: Container(
+                                  width: 54 * scale,
+                                  height: 54 * scale,
+                                  decoration: BoxDecoration(
+                                    shape: BoxShape.circle,
+                                    color: _currentPage > 0
+                                        ? const Color(0xFF14B890)
+                                        : const Color(0xFFD0D5DD),
+                                    boxShadow: _currentPage > 0
+                                        ? [
+                                            BoxShadow(
+                                              color: const Color(
+                                                0xFF14B890,
+                                              ).withOpacity(0.35),
+                                              blurRadius: 18 * scale,
+                                              offset: Offset(0, 6 * scale),
+                                            ),
+                                          ]
+                                        : [],
+                                  ),
+                                  child: const Icon(
+                                    Icons.chevron_left_rounded,
+                                    color: Colors.white,
+                                    size: 22,
+                                  ),
+                                ),
+                              ),
+                              // Right arrow button
+                              GestureDetector(
+                                onTap: () => _onNextPressed(context),
+                                child: Container(
+                                  width: 54 * scale,
+                                  height: 54 * scale,
+                                  decoration: BoxDecoration(
+                                    shape: BoxShape.circle,
+                                    color: const Color(0xFF14B890),
+                                    boxShadow: [
+                                      BoxShadow(
+                                        color: const Color(
+                                          0xFF14B890,
+                                        ).withOpacity(0.35),
                                         blurRadius: 18 * scale,
                                         offset: Offset(0, 6 * scale),
                                       ),
-                                    ]
-                                  : [],
-                            ),
-                            child: const Icon(
-                              Icons.chevron_left_rounded,
-                              color: Colors.white,
-                              size: 22,
-                            ),
-                          ),
-                        ),
-                        // Right arrow button
-                        GestureDetector(
-                          onTap: () => _onNextPressed(context),
-                          child: Container(
-                            width: 54 * scale,
-                            height: 54 * scale,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: const Color(0xFF14B890),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: const Color(0xFF14B890)
-                                      .withOpacity(0.35),
-                                  blurRadius: 18 * scale,
-                                  offset: Offset(0, 6 * scale),
+                                    ],
+                                  ),
+                                  child: const Icon(
+                                    Icons.chevron_right_rounded,
+                                    color: Colors.white,
+                                    size: 22,
+                                  ),
                                 ),
-                              ],
-                            ),
-                            child: const Icon(
-                              Icons.chevron_right_rounded,
-                              color: Colors.white,
-                              size: 22,
-                            ),
+                              ),
+                            ],
                           ),
-                        ),
                       ],
                     ),
-                ],
-              ),
                   ),
                 ),
               ),

--- a/lib/screens/payouts/payouts_screen.dart
+++ b/lib/screens/payouts/payouts_screen.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
+import 'dart:math' as math;
+import 'dart:async';
 import 'package:intl/intl.dart';
+import 'package:showcaseview/showcaseview.dart';
 
+import '../../theme/app_colors.dart';
 import '../../models/user_model.dart';
 import '../../services/api_service.dart';
+import '../../services/guide_preferences.dart';
 import '../../services/tab_router.dart';
-import '../../theme/app_colors.dart';
 
 class PayoutsScreen extends StatefulWidget {
   const PayoutsScreen({super.key});
@@ -15,40 +19,58 @@ class PayoutsScreen extends StatefulWidget {
 
 class _PayoutsScreenState extends State<PayoutsScreen> {
   final ApiService _apiService = ApiService();
+  final GlobalKey _guideKpiKey = GlobalKey();
   final NumberFormat _currencyFormat = NumberFormat.decimalPattern('en_IN');
-  final DateFormat _timeFormat = DateFormat('h:mm a');
-  static const List<String> _commonUpiHandles = <String>[
-    '@ybl',
-    '@ibl',
-    '@axl',
-    '@okaxis',
-    '@okhdfcbank',
-    '@okicici',
-    '@oksbi',
-    '@paytm',
-    '@upi',
-  ];
+  final DateFormat _dateFormat = DateFormat('d MMM yyyy');
+  final DateFormat _monthFormat = DateFormat('MMMM yyyy');
 
   List<_PayoutEntry> _payouts = const <_PayoutEntry>[];
   User? _user;
+  Map<String, dynamic>? _policy;
   bool _isLoading = true;
+  bool _shouldShowGuide = false;
+  bool _guidePreferenceResolved = false;
+  bool _guideStarted = false;
   DateTime _lastUpdated = DateTime.now();
+
   String _primaryUpi = '';
-  int _selectedRange = 0;
-  DateTimeRange? _customDateRange;
+  String? _backupUpi;
+  bool _primaryVerified = true;
+  bool _backupVerified = false;
 
   @override
   void initState() {
     super.initState();
     _loadPayoutData();
+    unawaited(_resolveGuidePreference());
+  }
+
+  Future<void> _resolveGuidePreference() async {
+    final shouldShow = await GuidePreferences.shouldShow(
+      GuidePreferences.payoutsGuideSeen,
+    );
+    if (!mounted) return;
+    setState(() {
+      _shouldShowGuide = shouldShow;
+      _guidePreferenceResolved = true;
+    });
+  }
+
+  void _maybeStartGuide(BuildContext context) {
+    if (!_guidePreferenceResolved || !_shouldShowGuide || _guideStarted) return;
+    _guideStarted = true;
+    unawaited(GuidePreferences.markSeen(GuidePreferences.payoutsGuideSeen));
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ShowCaseWidget.of(context).startShowCase([_guideKpiKey]);
+    });
   }
 
   Future<void> _loadPayoutData() async {
-    if (mounted) {
-      setState(() => _isLoading = true);
-    }
+    setState(() => _isLoading = true);
 
     User user = const User.empty();
+    Map<String, dynamic> policy = <String, dynamic>{};
     Map<String, dynamic> dashboard = <String, dynamic>{};
     final loadIssues = <String>[];
 
@@ -67,6 +89,15 @@ class _PayoutsScreenState extends State<PayoutsScreen> {
     }
 
     try {
+      policy = await _apiService.getPolicy('me');
+    } catch (error) {
+      if (!_isAuthRelatedError(error)) {
+        loadIssues.add('policy');
+      }
+      policy = <String, dynamic>{};
+    }
+
+    try {
       dashboard = await _apiService.getPayoutDashboard();
     } catch (error) {
       if (!_isAuthRelatedError(error)) {
@@ -75,37 +106,67 @@ class _PayoutsScreenState extends State<PayoutsScreen> {
       dashboard = <String, dynamic>{};
     }
 
-    final transfers = (dashboard['transfers'] as List<dynamic>? ?? const <dynamic>[])
-        .whereType<Map<String, dynamic>>()
-        .toList();
+    final transfers =
+        (dashboard['transfers'] as List<dynamic>? ?? const <dynamic>[])
+            .whereType<Map<String, dynamic>>()
+            .toList();
 
-    final payouts = transfers
-        .map(
-          (item) => _PayoutEntry(
-            date: DateTime.tryParse(_coerceString(item['createdAt'])) ?? DateTime.now(),
-            triggerType: _coerceString(item['note'], fallback: 'Claim payout'),
-            triggerRawType: _coerceString(item['provider'], fallback: 'payout'),
-            status: _coerceString(item['status'], fallback: 'pending'),
-            amount: (item['amount'] as num?)?.round() ?? 0,
-            upiRef: _coerceString(item['providerPayoutId'], fallback: _coerceString(item['id'])),
-            upiId: _coerceString(item['upiId'], fallback: _coerceString(dashboard['primaryUpi'])),
-          ),
-        )
-        .toList()
-      ..sort((a, b) => b.date.compareTo(a.date));
+    final payouts =
+        transfers
+            .map(
+              (item) => _PayoutEntry(
+                date:
+                    DateTime.tryParse(_coerceString(item['createdAt'])) ??
+                    DateTime.now(),
+                triggerType: _coerceString(
+                  item['note'],
+                  fallback: 'Claim payout',
+                ),
+                triggerRawType: _coerceString(
+                  item['provider'],
+                  fallback: 'payout',
+                ),
+                amount: (item['amount'] as num?)?.round() ?? 0,
+                upiRef: _coerceString(
+                  item['providerPayoutId'],
+                  fallback: _coerceString(item['id']),
+                ),
+              ),
+            )
+            .toList()
+          ..sort((a, b) => b.date.compareTo(a.date));
 
     if (!mounted) return;
     setState(() {
       _user = user;
+      _policy = policy;
       _payouts = payouts;
       _primaryUpi = _coerceString(dashboard['primaryUpi']);
+      _backupUpi = _coerceString(dashboard['backupUpi']).isEmpty
+          ? null
+          : _coerceString(dashboard['backupUpi']);
+      _primaryVerified = dashboard['primaryVerified'] == true;
+      _backupVerified = dashboard['backupVerified'] == true;
       _lastUpdated = DateTime.now();
       _isLoading = false;
     });
 
     if (loadIssues.isNotEmpty && mounted) {
+      final issueText = switch (loadIssues.first) {
+        'profile' => 'Could not load profile details.',
+        'policy' => 'Could not load policy details.',
+        'payouts' => 'Could not refresh payout details.',
+        _ => 'Could not refresh payout details.',
+      };
+
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Some payout details could not be refreshed.')),
+        SnackBar(
+          content: Text(
+            loadIssues.length == 1
+                ? issueText
+                : 'Some payout details could not be refreshed.',
+          ),
+        ),
       );
     }
   }
@@ -121,19 +182,26 @@ class _PayoutsScreenState extends State<PayoutsScreen> {
 
   Future<void> _refreshPayouts() => _loadPayoutData();
 
+  // ─── Entry point ──────────────────────────────────────────────────────────
+
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final pageBackground = isDark
+        ? AppColors.nightBackground
+        : AppColors.background;
+
     if (_isLoading) {
-      return const Scaffold(
-        backgroundColor: AppColors.background,
+      return Scaffold(
+        backgroundColor: pageBackground,
         body: Center(child: CircularProgressIndicator()),
       );
     }
 
     final user = _user;
     if (user == null) {
-      return const Scaffold(
-        backgroundColor: AppColors.background,
+      return Scaffold(
+        backgroundColor: pageBackground,
         body: Center(
           child: Text(
             'Payout data unavailable. Please retry.',
@@ -143,563 +211,1413 @@ class _PayoutsScreenState extends State<PayoutsScreen> {
       );
     }
 
-    final settledPayouts = _settledPayoutsForRange(_selectedRange);
-    final latestSettledPayout = settledPayouts.isNotEmpty ? settledPayouts.first : null;
-    final weeklyTotal = _totalReceivedForRange(_selectedRange);
-    final recentCreditedUpi = _recentCreditedUpi(latestSettledPayout);
+    final now = DateTime.now();
+    final currentMonthData = _monthlyData(now);
+    final previousMonthData = _monthlyData(DateTime(now.year, now.month - 1));
+    final totalPremiumsPaid = ((_policy?['weeklyPremium'] as num? ?? 0) * 4)
+        .round();
+    final totalPayoutsReceived = _payouts.fold<int>(0, (s, p) => s + p.amount);
+    final estimatedWeeklyEarnings = (user.totalEarnings / 4).round();
+    final averageWeeklyPayout = _payouts.isEmpty
+        ? 0
+        : (totalPayoutsReceived / 4).round();
 
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      body: Stack(
-        children: [
-          const Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            child: SizedBox(
-              height: 200,
-              child: CustomPaint(
-                painter: _PayoutsTopBackgroundPainter(),
-              ),
-            ),
-          ),
-          SafeArea(
-            child: RefreshIndicator(
-              onRefresh: _refreshPayouts,
-              child: ListView(
-                physics: const AlwaysScrollableScrollPhysics(),
-                padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
-                children: [
-                  _buildTopUtilityButtons(),
-                  const SizedBox(height: 14),
-                  const Text(
-                    'Payouts',
-                    style: TextStyle(
-                      fontSize: 30,
-                      fontWeight: FontWeight.w800,
-                      color: AppColors.textPrimary,
-                      letterSpacing: -0.4,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  const Text(
-                    'Track trigger settlements and payout receipts.',
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: AppColors.textSecondary,
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  _buildWeekSelector(),
-                  const SizedBox(height: 16),
-                  _buildReceiptHeroCard(
-                    title: _rangeTitle(_selectedRange),
-                    weeklyTotal: weeklyTotal,
-                    recentCreditedUpi: recentCreditedUpi,
-                  ),
-                  const SizedBox(height: 16),
-                  _buildReceiptTimeline(
-                    settledPayouts,
-                    range: _selectedRange,
-                  ),
-                  const SizedBox(height: 14),
-                  const Divider(height: 1, thickness: 1, color: Color(0xFFE6E0D7)),
-                  const SizedBox(height: 18),
-                  _buildReceiptActions(),
-                  const SizedBox(height: 18),
-                  const Text(
-                    'Quick Actions',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w900,
-                      color: AppColors.textPrimary,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  _buildPayoutAccountCard(),
-                  const SizedBox(height: 14),
-                  Text(
-                    'Updated ${_timeFormat.format(_lastUpdated)}',
-                    style: const TextStyle(
-                      fontSize: 11,
-                      color: AppColors.textTertiary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTopUtilityButtons() {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        _utilityIconButton(
-          icon: Icons.arrow_back,
-          tooltip: 'Back to Home',
-          onTap: _openHome,
-        ),
-        const SizedBox(width: 42, height: 42),
-      ],
-    );
-  }
-
-  Widget _utilityIconButton({
-    required IconData icon,
-    required String tooltip,
-    required VoidCallback onTap,
-  }) {
-    return Tooltip(
-      message: tooltip,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: onTap,
-        child: Container(
-          width: 42,
-          height: 42,
-          decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.2),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: Colors.white.withValues(alpha: 0.28)),
-          ),
-          child: Icon(icon, size: 21, color: AppColors.textPrimary),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildWeekSelector() {
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(
-        children: [
-          _weekPill(
-            label: 'This week',
-            selected: _selectedRange == 0,
-            onTap: () => setState(() => _selectedRange = 0),
-          ),
-          const SizedBox(width: 8),
-          _weekPill(
-            label: 'Previous week',
-            selected: _selectedRange == 1,
-            onTap: () => setState(() => _selectedRange = 1),
-          ),
-          const SizedBox(width: 8),
-          _weekPill(
-            label: 'All time',
-            selected: _selectedRange == 2,
-            onTap: () => setState(() => _selectedRange = 2),
-          ),
-          const SizedBox(width: 8),
-          _weekPill(
-            label: _customRangePillLabel(),
-            selected: _selectedRange == 3,
-            onTap: _onCustomRangeTap,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _weekPill({
-    required String label,
-    required bool selected,
-    required VoidCallback onTap,
-  }) {
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(999),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: selected ? AppColors.primary : Colors.white,
-          borderRadius: BorderRadius.circular(999),
-          border: Border.all(
-            color: selected ? AppColors.primary : AppColors.border,
-          ),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 12,
-            fontWeight: FontWeight.w700,
-            color: selected ? Colors.white : AppColors.textPrimary,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildReceiptHeroCard({
-    required String title,
-    required int weeklyTotal,
-    required String recentCreditedUpi,
-  }) {
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
-      decoration: BoxDecoration(
-        color: const Color(0xFF1F7A48),
-        borderRadius: BorderRadius.circular(28),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            title,
-            style: const TextStyle(
-              fontSize: 19,
-              fontWeight: FontWeight.w700,
-              color: Colors.white,
-              height: 1.05,
-            ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            '₹${_currencyFormat.format(weeklyTotal)}',
-            style: const TextStyle(
-              fontSize: 42,
-              fontWeight: FontWeight.w800,
-              color: Colors.white,
-              height: 0.95,
-              letterSpacing: -1.4,
-            ),
-          ),
-          const SizedBox(height: 12),
-          Text(
-            'Credited to $recentCreditedUpi · just now',
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.w500,
-              color: Colors.white.withValues(alpha: 0.88),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildReceiptTimeline(
-    List<_PayoutEntry> settledPayouts, {
-    required int range,
-  }) {
-    final steps = settledPayouts
-        .map(
-          (entry) => _ReceiptStep(
-            title: '(₹${_currencyFormat.format(entry.amount)}) received (${_claimLabel(entry)})',
-            subtitle: '${_formatTimeLabel(entry.date)} · Settled to wallet',
-          ),
-        )
-        .toList();
-
-    if (steps.isEmpty) {
-      steps.add(
-        _ReceiptStep(
-          title: 'No settled payouts yet',
-          subtitle: '${_rangeLabel(range)} · Waiting for settlement',
-        ),
-      );
-    }
-
-    return Column(
-      children: [
-        for (var index = 0; index < steps.length; index++)
-          _timelineStep(
-            step: steps[index],
-            isLast: index == steps.length - 1,
-          ),
-      ],
-    );
-  }
-
-  Widget _timelineStep({
-    required _ReceiptStep step,
-    required bool isLast,
-  }) {
-    return Padding(
-      padding: EdgeInsets.only(bottom: isLast ? 0 : 18),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 20,
-            child: Column(
+    return ShowCaseWidget(
+      builder: (guideContext) {
+        _maybeStartGuide(guideContext);
+        return Scaffold(
+          backgroundColor: pageBackground,
+          body: SafeArea(
+            top: false,
+            child: Stack(
               children: [
-                Container(
-                  width: 16,
-                  height: 16,
-                  decoration: const BoxDecoration(
-                    color: Color(0xFF31C8A2),
-                    shape: BoxShape.circle,
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  child: SizedBox(
+                    height: 205,
+                    child: CustomPaint(
+                      painter: _PayoutsTopBackgroundPainter(isDark: isDark),
+                    ),
                   ),
                 ),
-                if (!isLast)
-                  Container(
-                    width: 3,
-                    height: 30,
-                    margin: const EdgeInsets.only(top: 2),
-                    decoration: BoxDecoration(
-                      color: const Color(0xFFE2DDD4),
-                      borderRadius: BorderRadius.circular(99),
-                    ),
-                  )
-                else
-                  const SizedBox(height: 32),
+                RefreshIndicator(
+                  onRefresh: _refreshPayouts,
+                  child: ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.fromLTRB(0, 0, 0, 28),
+                    children: [
+                      // ── Hero gradient header ──────────────────────────────────────
+                      _buildHeroHeader(
+                        user: user,
+                        totalPremiumsPaid: totalPremiumsPaid,
+                        totalPayoutsReceived: totalPayoutsReceived,
+                        currentMonthData: currentMonthData,
+                      ),
+                      // ── Body content ──────────────────────────────────────────────
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Showcase(
+                              key: _guideKpiKey,
+                              title: 'Payout KPIs',
+                              description:
+                                  'Track this month\'s payouts, transfer reliability, and protection value at a glance.',
+                              child: _buildKpiStrip(
+                                currentMonthData: currentMonthData,
+                              ),
+                            ),
+                            const SizedBox(height: 24),
+                            _buildSectionHeader(
+                              title: 'Performance',
+                              subtitle:
+                                  'Monthly trend and your protection ratio',
+                            ),
+                            const SizedBox(height: 10),
+                            _buildMonthlySummaryCard(
+                              currentMonthData: currentMonthData,
+                              previousMonthData: previousMonthData,
+                            ),
+                            const SizedBox(height: 10),
+                            _buildValueRatioCard(
+                              estimatedWeeklyEarnings: estimatedWeeklyEarnings,
+                              averageWeeklyPayout: averageWeeklyPayout,
+                            ),
+                            const SizedBox(height: 24),
+                            _buildSectionHeader(
+                              title: 'Payout Accounts',
+                              subtitle: 'Manage where settlements are sent',
+                            ),
+                            const SizedBox(height: 10),
+                            _buildUpiManagementCard(context),
+                            const SizedBox(height: 24),
+                            _buildSectionHeader(
+                              title: 'Statements',
+                              subtitle:
+                                  'Download records for accounting and tax',
+                            ),
+                            const SizedBox(height: 10),
+                            _buildStatementCard(context),
+                            const SizedBox(height: 24),
+                            _buildSectionHeader(
+                              title: 'Recent Transfers',
+                              subtitle:
+                                  '${_payouts.length} settled payouts · pull down to refresh',
+                            ),
+                            const SizedBox(height: 10),
+                            ..._payouts.map(
+                              (entry) => Padding(
+                                padding: const EdgeInsets.only(bottom: 8),
+                                child: _buildPayoutTile(entry),
+                              ),
+                            ),
+                            if (_payouts.isEmpty)
+                              _emptyState(
+                                icon: Icons.account_balance_wallet_outlined,
+                                message:
+                                    'No settled payouts yet.\nYour transfers will appear here.',
+                              ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               ],
             ),
           ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.only(top: 1),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    step.title,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                      color: Color(0xFF1E2520),
-                      height: 1.05,
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    step.subtitle,
-                    style: const TextStyle(
-                      fontSize: 12,
-                      color: AppColors.textTertiary,
-                      height: 1.15,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 
-  Widget _buildPayoutAccountCard() {
-    final upi = _primaryUpi.isNotEmpty ? _primaryUpi : 'No UPI added';
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(22),
-        border: Border.all(color: const Color(0xFFE5DED3)),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.04),
-            blurRadius: 18,
-            offset: const Offset(0, 6),
-          ),
-        ],
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+  // ─── Hero header ──────────────────────────────────────────────────────────
+
+  Widget _buildHeroHeader({
+    required User user,
+    required int totalPremiumsPaid,
+    required int totalPayoutsReceived,
+    required _MonthlySummary currentMonthData,
+  }) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final primaryText = isDark ? Colors.white : AppColors.textPrimary;
+    final secondaryText = isDark ? Colors.white70 : AppColors.textSecondary;
+    final heroChipBg = isDark
+        ? Colors.white.withValues(alpha: 0.14)
+        : Colors.white.withValues(alpha: 0.72);
+    final heroChipBorder = isDark
+        ? Colors.white.withValues(alpha: 0.2)
+        : Colors.white.withValues(alpha: 0.42);
+    final netValue = totalPayoutsReceived - totalPremiumsPaid;
+    final isPositive = netValue >= 0;
+    final initials = _userInitials(user.name);
+
+    return SafeArea(
+      bottom: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                const Text(
-                  'Primary UPI',
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: AppColors.textSecondary,
-                    height: 1.1,
-                  ),
+                _headerIconButton(
+                  icon: Icons.arrow_back_rounded,
+                  onTap: _openHome,
                 ),
-                const SizedBox(height: 6),
-                Text(
-                  upi,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                    color: AppColors.textPrimary,
-                    height: 1.05,
-                  ),
-                ),
-                const SizedBox(height: 15),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
+                Row(
                   children: [
-                    _accountActionChip(
-                      label: 'Update UPI ID',
-                      onTap: () => _showUpdateUpiSheet(slot: 'primary'),
+                    _headerIconButton(
+                      icon: Icons.notifications_none_rounded,
+                      onTap: () => _showSimpleInfo('No new payout alerts'),
                     ),
-                    _accountActionChip(
-                      label: 'Add backup UPI',
-                      onTap: () => _showUpdateUpiSheet(slot: 'backup'),
+                    const SizedBox(width: 8),
+                    GestureDetector(
+                      onTap: () => _showAccountSheet(user),
+                      child: Container(
+                        width: 38,
+                        height: 38,
+                        decoration: BoxDecoration(
+                          color: AppColors.primary,
+                          shape: BoxShape.circle,
+                        ),
+                        child: Center(
+                          child: Text(
+                            initials,
+                            style: const TextStyle(
+                              fontSize: 13,
+                              fontWeight: FontWeight.w700,
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
+                      ),
                     ),
                   ],
                 ),
               ],
             ),
+            const SizedBox(height: 16),
+            Text(
+              'Payouts',
+              style: TextStyle(
+                fontSize: 28,
+                fontWeight: FontWeight.w800,
+                color: primaryText,
+                letterSpacing: -0.5,
+                height: 1.1,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              'Updated ${DateFormat('h:mm a').format(_lastUpdated)}',
+              style: TextStyle(fontSize: 12, color: secondaryText),
+            ),
+            const SizedBox(height: 14),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(14),
+              decoration: BoxDecoration(
+                color: AppColors.primary,
+                borderRadius: BorderRadius.circular(18),
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: _heroPill(
+                      label: 'Total received',
+                      value: '₹${_currencyFormat.format(totalPayoutsReceived)}',
+                      icon: Icons.south_west_rounded,
+                      isDark: isDark,
+                      chipBg: heroChipBg,
+                      chipBorder: heroChipBorder,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: _heroPill(
+                      label: isPositive ? 'Net gain' : 'Coverage note',
+                      value: isPositive
+                          ? '+₹${_currencyFormat.format(netValue.abs())}'
+                          : _payoutMomentumQuote(
+                              totalPayoutsReceived: totalPayoutsReceived,
+                              payoutCount: _payouts.length,
+                            ),
+                      icon: isPositive
+                          ? Icons.trending_up_rounded
+                          : Icons.shield_outlined,
+                      valueColor: isPositive
+                          ? const Color(0xFF6EFFC2)
+                          : (isDark ? Colors.white : AppColors.textPrimary),
+                      isDark: isDark,
+                      chipBg: heroChipBg,
+                      chipBorder: heroChipBorder,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _heroPill({
+    required String label,
+    required String value,
+    required IconData icon,
+    Color valueColor = Colors.white,
+    required bool isDark,
+    required Color chipBg,
+    required Color chipBorder,
+  }) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: BoxDecoration(
+        color: chipBg,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: chipBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                icon,
+                size: 13,
+                color: isDark ? Colors.white70 : AppColors.textPrimary,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 11,
+                  color: isDark ? Colors.white70 : AppColors.textPrimary,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 5),
+          Text(
+            value,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 17,
+              fontWeight: FontWeight.w800,
+              color: valueColor,
+              letterSpacing: -0.3,
+              height: 1.2,
+            ),
           ),
         ],
       ),
     );
   }
 
-  Widget _accountActionChip({
-    required String label,
+  // ignore: unused_element
+  Widget _iconButton({required IconData icon, required VoidCallback onTap}) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 38,
+        height: 38,
+        decoration: BoxDecoration(
+          color: isDark
+              ? Colors.white.withValues(alpha: 0.14)
+              : AppColors.cardBackground,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: isDark
+                ? Colors.white.withValues(alpha: 0.25)
+                : AppColors.border,
+          ),
+        ),
+        child: Icon(
+          icon,
+          size: 18,
+          color: isDark ? Colors.white : AppColors.textPrimary,
+        ),
+      ),
+    );
+  }
+
+  Widget _headerIconButton({
+    required IconData icon,
     required VoidCallback onTap,
   }) {
-    return InkWell(
+    return GestureDetector(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(10),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        width: 38,
+        height: 38,
+        decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
+        child: Icon(icon, size: 18, color: AppColors.textPrimary),
+      ),
+    );
+  }
+
+  // ─── KPI strip ────────────────────────────────────────────────────────────
+
+  Widget _buildKpiStrip({required _MonthlySummary currentMonthData}) {
+    return Row(
+      children: [
+        Expanded(
+          child: _kpiChip(
+            label: 'This month',
+            value: '₹${_currencyFormat.format(currentMonthData.totalReceived)}',
+            icon: Icons.calendar_today_outlined,
+            iconColor: const Color(0xFF185FA5),
+            iconBg: const Color(0xFFE6F1FB),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _kpiChip(
+            label: 'Avg payout',
+            value: '₹${_currencyFormat.format(currentMonthData.average)}',
+            icon: Icons.show_chart_rounded,
+            iconColor: const Color(0xFF3B6D11),
+            iconBg: const Color(0xFFEAF3DE),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _kpiChip(
+            label: 'Transfers',
+            value: '${_payouts.length}',
+            icon: Icons.swap_horiz_rounded,
+            iconColor: AppColors.primary,
+            iconBg: AppColors.accentLight,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _kpiChip({
+    required String label,
+    required String value,
+    required IconData icon,
+    required Color iconColor,
+    required Color iconBg,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = Theme.of(context).colorScheme.surface;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(10, 12, 10, 12),
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.nightSurface : surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: isDark ? AppColors.nightBorder : AppColors.border,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 28,
+            height: 28,
+            decoration: BoxDecoration(
+              color: iconBg,
+              borderRadius: BorderRadius.circular(7),
+            ),
+            child: Icon(icon, size: 14, color: iconColor),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 10,
+              color: isDark ? Colors.white70 : AppColors.textSecondary,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w800,
+              color: isDark ? Colors.white : AppColors.textPrimary,
+              letterSpacing: -0.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ─── Section header ───────────────────────────────────────────────────────
+
+  Widget _buildSectionHeader({
+    required String title,
+    required String subtitle,
+  }) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.72 : 0.80,
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: primaryText,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(subtitle, style: TextStyle(fontSize: 11, color: secondaryText)),
+      ],
+    );
+  }
+
+  // ─── Monthly summary card ─────────────────────────────────────────────────
+
+  Widget _buildMonthlySummaryCard({
+    required _MonthlySummary currentMonthData,
+    required _MonthlySummary previousMonthData,
+  }) {
+    final thisMonth = currentMonthData.totalReceived;
+    final lastMonth = previousMonthData.totalReceived;
+    final maxValue = math.max(thisMonth, lastMonth).clamp(1, 999999);
+    final changePercent = lastMonth == 0
+        ? null
+        : ((thisMonth - lastMonth) / lastMonth * 100).round();
+
+    return _card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Three metrics in a row
+          Row(
+            children: [
+              Expanded(
+                child: _metricItem(
+                  label: 'Total received',
+                  value: '₹${_currencyFormat.format(thisMonth)}',
+                ),
+              ),
+              _verticalDivider(),
+              Expanded(
+                child: _metricItem(
+                  label: 'Payouts',
+                  value: '${currentMonthData.count}',
+                ),
+              ),
+              _verticalDivider(),
+              Expanded(
+                child: _metricItem(
+                  label: 'Avg / claim',
+                  value: '₹${_currencyFormat.format(currentMonthData.average)}',
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          // Month-over-month change indicator
+          if (changePercent != null)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: changePercent >= 0
+                    ? const Color(0xFFEAF3DE)
+                    : const Color(0xFFFCEBEB),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    changePercent >= 0
+                        ? Icons.arrow_upward_rounded
+                        : Icons.arrow_downward_rounded,
+                    size: 12,
+                    color: changePercent >= 0
+                        ? const Color(0xFF3B6D11)
+                        : const Color(0xFFA32D2D),
+                  ),
+                  const SizedBox(width: 3),
+                  Text(
+                    '${changePercent.abs()}% vs last month',
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: changePercent >= 0
+                          ? const Color(0xFF3B6D11)
+                          : const Color(0xFFA32D2D),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          const SizedBox(height: 14),
+          // Bar comparison
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Expanded(
+                child: _bar(
+                  label: 'This month',
+                  amount: thisMonth,
+                  heightFactor: thisMonth / maxValue,
+                  color: AppColors.primary,
+                  maxBarHeight: 60,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: _bar(
+                  label: 'Last month',
+                  amount: lastMonth,
+                  heightFactor: lastMonth / maxValue,
+                  color: const Color(0xFFB5D4F4),
+                  maxBarHeight: 60,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _bar({
+    required String label,
+    required int amount,
+    required double heightFactor,
+    required Color color,
+    required double maxBarHeight,
+  }) {
+    final clampedFactor = heightFactor.clamp(0.04, 1.0);
+    final barHeight = maxBarHeight * clampedFactor;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          height: maxBarHeight,
+          alignment: Alignment.bottomLeft,
+          child: Container(
+            width: double.infinity,
+            height: barHeight,
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(6),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 11,
+            color: AppColors.textSecondary,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(height: 1),
+        Text(
+          '₹${_currencyFormat.format(amount)}',
+          style: const TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: AppColors.textPrimary,
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ─── Protection value ratio card ──────────────────────────────────────────
+
+  Widget _buildValueRatioCard({
+    required int estimatedWeeklyEarnings,
+    required int averageWeeklyPayout,
+  }) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.70 : 0.78,
+    );
+    final maxValue = math
+        .max(estimatedWeeklyEarnings, averageWeeklyPayout)
+        .clamp(1, 999999);
+    final coverageRatio = estimatedWeeklyEarnings == 0
+        ? 0.0
+        : (averageWeeklyPayout / estimatedWeeklyEarnings).clamp(0.0, 1.0);
+
+    return _card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Protection value ratio',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: primaryText,
+                  ),
+                ),
+              ),
+              // Coverage percentage badge
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: AppColors.accentLight,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  '${(coverageRatio * 100).round()}% covered',
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.primary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Payouts vs estimated weekly earnings',
+            style: TextStyle(fontSize: 11, color: secondaryText),
+          ),
+          const SizedBox(height: 14),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Expanded(
+                child: _bar(
+                  label: 'Est. earnings',
+                  amount: estimatedWeeklyEarnings,
+                  heightFactor: estimatedWeeklyEarnings / maxValue,
+                  color: const Color(0xFFD3D1C7),
+                  maxBarHeight: 80,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: _bar(
+                  label: 'Payouts received',
+                  amount: averageWeeklyPayout,
+                  heightFactor: averageWeeklyPayout / maxValue,
+                  color: AppColors.primary,
+                  maxBarHeight: 80,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ─── UPI management card ──────────────────────────────────────────────────
+
+  Widget _buildUpiManagementCard(BuildContext context) {
+    return _card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _upiRow(
+            context: context,
+            label: 'Primary UPI',
+            upiId: _primaryUpi,
+            verified: _primaryVerified,
+            onChangeLabel: 'Change',
+            onChange: () => _editUpi(
+              context,
+              title: 'Change primary UPI',
+              currentValue: _primaryUpi,
+              onSaved: (v) => setState(() {
+                _primaryUpi = v;
+                _primaryVerified = false;
+              }),
+            ),
+            onVerify: _primaryVerified
+                ? null
+                : () {
+                    _verifyPrimary();
+                  },
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 14),
+            child: Container(height: 1, color: AppColors.border),
+          ),
+          _upiRow(
+            context: context,
+            label: 'Backup UPI',
+            upiId: _backupUpi ?? 'Not added',
+            verified: _backupVerified,
+            onChangeLabel: _backupUpi == null ? 'Add' : 'Change',
+            onChange: () => _editUpi(
+              context,
+              title: _backupUpi == null
+                  ? 'Add backup UPI'
+                  : 'Change backup UPI',
+              currentValue: _backupUpi,
+              onSaved: (v) => setState(() {
+                _backupUpi = v;
+                _backupVerified = false;
+              }),
+            ),
+            onVerify: _backupUpi == null
+                ? null
+                : () {
+                    _verifyBackup();
+                  },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _upiRow({
+    required BuildContext context,
+    required String label,
+    required String upiId,
+    required bool verified,
+    required String onChangeLabel,
+    required VoidCallback onChange,
+    VoidCallback? onVerify,
+  }) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final primaryText = theme.colorScheme.onSurface;
+    final secondaryText = theme.colorScheme.onSurface.withValues(
+      alpha: isDark ? 0.68 : 0.78,
+    );
+    final isAdded = upiId.toLowerCase() != 'not added';
+
+    return Row(
+      children: [
+        // Left: icon + text
+        Container(
+          width: 36,
+          height: 36,
+          decoration: BoxDecoration(
+            color: verified && isAdded
+                ? const Color(0xFFEAF3DE)
+                : const Color(0xFFF1EFE8),
+            borderRadius: BorderRadius.circular(9),
+          ),
+          child: Icon(
+            verified && isAdded
+                ? Icons.verified_outlined
+                : Icons.account_balance_wallet_outlined,
+            size: 17,
+            color: verified && isAdded
+                ? const Color(0xFF3B6D11)
+                : secondaryText,
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: secondaryText,
+                ),
+              ),
+              const SizedBox(height: 1),
+              Text(
+                upiId,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: isAdded ? primaryText : secondaryText,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 8),
+        // Right: verified badge + action buttons
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+              decoration: BoxDecoration(
+                color: verified && isAdded
+                    ? const Color(0xFFEAF3DE)
+                    : const Color(0xFFFAEEDA),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text(
+                verified && isAdded ? 'Verified' : 'Unverified',
+                style: TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  color: verified && isAdded
+                      ? const Color(0xFF3B6D11)
+                      : const Color(0xFFBA7517),
+                ),
+              ),
+            ),
+            const SizedBox(height: 6),
+            Row(
+              children: [
+                _smallAction(label: onChangeLabel, onTap: onChange),
+                if (onVerify != null) ...[
+                  const SizedBox(width: 6),
+                  _smallAction(label: 'Verify', onTap: onVerify, primary: true),
+                ],
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _smallAction({
+    required String label,
+    required VoidCallback onTap,
+    bool primary = false,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
         decoration: BoxDecoration(
-          color: AppColors.accentLight,
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: AppColors.border),
+          color: primary ? AppColors.accentLight : Colors.transparent,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: primary
+                ? AppColors.primary.withValues(alpha: 0.4)
+                : AppColors.border,
+          ),
         ),
         child: Text(
           label,
-          style: const TextStyle(
-            fontSize: 12,
+          style: TextStyle(
+            fontSize: 11,
             fontWeight: FontWeight.w600,
-            color: AppColors.textPrimary,
+            color: primary ? AppColors.primary : AppColors.textSecondary,
           ),
         ),
       ),
     );
   }
 
-  String _withSelectedHandle(String input, String handle) {
-    final normalizedHandle = handle.startsWith('@') ? handle : '@$handle';
-    final value = input.trim().toLowerCase();
-    if (value.isEmpty) {
-      return 'name$normalizedHandle';
-    }
+  // ─── Statement card ───────────────────────────────────────────────────────
 
-    final atIndex = value.indexOf('@');
-    if (atIndex == -1) {
-      return '$value$normalizedHandle';
-    }
-
-    final userPart = value.substring(0, atIndex).trim();
-    return '${userPart.isEmpty ? 'name' : userPart}$normalizedHandle';
+  Widget _buildStatementCard(BuildContext context) {
+    return _card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFE6F1FB),
+                  borderRadius: BorderRadius.circular(9),
+                ),
+                child: const Icon(
+                  Icons.description_outlined,
+                  size: 17,
+                  color: Color(0xFF185FA5),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'PDF statements',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.textPrimary,
+                      ),
+                    ),
+                    Text(
+                      _monthFormat.format(DateTime.now()),
+                      style: const TextStyle(
+                        fontSize: 11,
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Row(
+            children: [
+              Expanded(
+                child: _statementButton(
+                  icon: Icons.download_outlined,
+                  label: 'This month',
+                  onTap: _showCurrentMonthStatement,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: _statementButton(
+                  icon: Icons.date_range_outlined,
+                  label: 'Custom range',
+                  onTap: () => _pickCustomRange(context),
+                  primary: true,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
   }
 
-  Future<void> _showUpdateUpiSheet({required String slot}) async {
-    String draftUpi = '';
-    final controller = TextEditingController();
+  Widget _statementButton({
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+    bool primary = false,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 11),
+        decoration: BoxDecoration(
+          color: primary ? AppColors.accentLight : Colors.transparent,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: primary
+                ? AppColors.primary.withValues(alpha: 0.4)
+                : AppColors.border,
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 15,
+              color: primary ? AppColors.primary : AppColors.textSecondary,
+            ),
+            const SizedBox(width: 5),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: primary ? AppColors.primary : AppColors.textSecondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ─── Payout tile ──────────────────────────────────────────────────────────
+
+  Widget _buildPayoutTile(_PayoutEntry entry) {
+    final iconData = _triggerIconData(entry.triggerRawType);
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = Theme.of(context).colorScheme.surface;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.nightSurface : surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: isDark ? AppColors.nightBorder : AppColors.border,
+        ),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 38,
+            height: 38,
+            decoration: BoxDecoration(
+              color: iconData.background,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(iconData.icon, size: 18, color: iconData.color),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  entry.triggerType,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: isDark ? Colors.white : AppColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  _dateFormat.format(entry.date),
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: isDark ? Colors.white70 : AppColors.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  'Ref: ${entry.upiRef}',
+                  style: TextStyle(
+                    fontSize: 10,
+                    color: isDark ? Colors.white60 : AppColors.textSecondary,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                '₹${_currencyFormat.format(entry.amount)}',
+                style: const TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w800,
+                  color: AppColors.primary,
+                  letterSpacing: -0.2,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFEAF3DE),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: const Text(
+                  'Settled',
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700,
+                    color: Color(0xFF3B6D11),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 6),
+              InkWell(
+                onTap: () => _showTransferReceipt(entry),
+                borderRadius: BorderRadius.circular(8),
+                child: const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                  child: Text(
+                    'Receipt',
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  Widget _card({required Widget child}) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = Theme.of(context).colorScheme.surface;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.nightSurface : surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? AppColors.nightBorder : AppColors.border,
+        ),
+      ),
+      child: child,
+    );
+  }
+
+  Widget _metricItem({required String label, required String value}) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 10,
+            color: isDark ? Colors.white70 : AppColors.textSecondary,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(height: 3),
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w800,
+            color: isDark ? Colors.white : AppColors.textPrimary,
+            letterSpacing: -0.2,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _verticalDivider() {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      width: 1,
+      height: 32,
+      color: isDark ? AppColors.nightBorder : AppColors.border,
+      margin: const EdgeInsets.symmetric(horizontal: 10),
+    );
+  }
+
+  Widget _emptyState({required IconData icon, required String message}) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = Theme.of(context).colorScheme.surface;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 32),
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.nightSurface : surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? AppColors.nightBorder : AppColors.border,
+        ),
+      ),
+      child: Column(
+        children: [
+          Icon(
+            icon,
+            size: 36,
+            color: isDark ? Colors.white70 : AppColors.textSecondary,
+          ),
+          const SizedBox(height: 10),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 13,
+              color: isDark ? Colors.white70 : AppColors.textSecondary,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  ({IconData icon, Color color, Color background}) _triggerIconData(
+    String rawType,
+  ) {
+    switch (rawType.toLowerCase()) {
+      case 'rainlock':
+        return (
+          icon: Icons.water_drop_outlined,
+          color: const Color(0xFF185FA5),
+          background: const Color(0xFFE6F1FB),
+        );
+      case 'trafficblock':
+        return (
+          icon: Icons.traffic_outlined,
+          color: const Color(0xFFBA7517),
+          background: const Color(0xFFFAEEDA),
+        );
+      case 'zonelock':
+        return (
+          icon: Icons.location_off_outlined,
+          color: const Color(0xFF993556),
+          background: const Color(0xFFFBEAF0),
+        );
+      case 'aqiguard':
+        return (
+          icon: Icons.air_outlined,
+          color: const Color(0xFF3B6D11),
+          background: const Color(0xFFEAF3DE),
+        );
+      case 'heatblock':
+        return (
+          icon: Icons.thermostat_outlined,
+          color: const Color(0xFFA32D2D),
+          background: const Color(0xFFFCEBEB),
+        );
+      default:
+        return (
+          icon: Icons.account_balance_wallet_outlined,
+          color: AppColors.primary,
+          background: AppColors.accentLight,
+        );
+    }
+  }
+
+  String _userInitials(String? name) {
+    final safeName = _coerceString(name);
+    final parts = safeName
+        .trim()
+        .split(' ')
+        .where((p) => p.isNotEmpty)
+        .toList();
+    if (parts.isEmpty) return '?';
+    if (parts.length == 1) return parts.first.substring(0, 1).toUpperCase();
+    return '${parts.first[0]}${parts.last[0]}'.toUpperCase();
+  }
+
+  String _coerceString(Object? value, {String fallback = ''}) {
+    if (value == null) return fallback;
+    final text = value.toString().trim();
+    return text.isEmpty ? fallback : text;
+  }
+
+  String _payoutMomentumQuote({
+    required int totalPayoutsReceived,
+    required int payoutCount,
+  }) {
+    if (payoutCount >= 3) return 'Strong cover';
+    if (totalPayoutsReceived > 0) return 'Covered';
+    return 'Safety active';
+  }
+
+  _MonthlySummary _monthlyData(DateTime month) {
+    final entries = _payouts.where(
+      (e) => e.date.year == month.year && e.date.month == month.month,
+    );
+    final count = entries.length;
+    final total = entries.fold<int>(0, (s, e) => s + e.amount);
+    return _MonthlySummary(
+      totalReceived: total,
+      count: count,
+      average: count == 0 ? 0 : (total / count).round(),
+    );
+  }
+
+  // ─── Actions / sheets ─────────────────────────────────────────────────────
+
+  Future<void> _editUpi(
+    BuildContext context, {
+    required String title,
+    required String? currentValue,
+    required ValueChanged<String> onSaved,
+  }) async {
+    final controller = TextEditingController(text: currentValue);
 
     await showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       showDragHandle: true,
       builder: (sheetContext) {
-        final isPrimary = slot == 'primary';
-        return StatefulBuilder(
-          builder: (context, setModalState) {
-            return Padding(
-              padding: EdgeInsets.fromLTRB(
-                16,
-                8,
-                16,
-                MediaQuery.of(sheetContext).viewInsets.bottom + 16,
+        return Padding(
+          padding: EdgeInsets.fromLTRB(
+            16,
+            8,
+            16,
+            math.max(0.0, MediaQuery.of(sheetContext).viewInsets.bottom) + 16,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.textPrimary,
+                ),
               ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    isPrimary ? 'Update UPI ID' : 'Add backup UPI',
-                    style: const TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.w700,
-                      color: AppColors.textPrimary,
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: controller,
-                    onChanged: (value) => draftUpi = value,
-                    decoration: const InputDecoration(
-                      labelText: 'UPI ID',
-                      hintText: 'name@bank',
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  if (!isPrimary) ...[
-                    const SizedBox(height: 10),
-                    const Text(
-                      'Common handles',
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.textSecondary,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: _commonUpiHandles.map((handle) {
-                        return ActionChip(
-                          label: Text(handle),
-                          onPressed: () {
-                            final next = _withSelectedHandle(draftUpi, handle);
-                            setModalState(() {
-                              draftUpi = next;
-                              controller.value = TextEditingValue(
-                                text: next,
-                                selection: TextSelection.collapsed(offset: next.length),
-                              );
-                            });
-                          },
-                        );
-                      }).toList(),
-                    ),
-                    const SizedBox(height: 6),
-                  ],
-                  const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      onPressed: () async {
-                        final value = draftUpi.trim().toLowerCase();
-                        if (value.isEmpty || !value.contains('@')) {
-                          _showSimpleInfo('Enter a valid UPI ID');
-                          return;
-                        }
-
-                        try {
-                          await _apiService.updatePayoutAccount(slot: slot, upiId: value);
-                          if (!sheetContext.mounted) return;
-                          Navigator.pop(sheetContext);
+              const SizedBox(height: 12),
+              TextField(
+                controller: controller,
+                decoration: const InputDecoration(
+                  labelText: 'UPI ID',
+                  hintText: 'name@bank',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    final value = controller.text.trim();
+                    if (value.isEmpty || !value.contains('@')) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Enter a valid UPI ID')),
+                      );
+                      return;
+                    }
+                    final isPrimary = title.toLowerCase().contains('primary');
+                    final messenger = ScaffoldMessenger.of(context);
+                    final navigator = Navigator.of(sheetContext);
+                    _apiService
+                        .updatePayoutAccount(
+                          slot: isPrimary ? 'primary' : 'backup',
+                          upiId: value,
+                        )
+                        .then((_) async {
+                          onSaved(value);
+                          navigator.pop();
                           await _refreshPayouts();
                           if (!mounted) return;
-                          _showSimpleInfo('UPI ID updated');
-                        } catch (_) {
+                          _showSimpleInfo('UPI updated successfully');
+                        })
+                        .catchError((_) {
                           if (!mounted) return;
-                          _showSimpleInfo('Failed to update UPI ID');
-                        }
-                      },
-                      child: const Text('Save UPI'),
-                    ),
-                  ),
-                ],
+                          messenger.showSnackBar(
+                            const SnackBar(
+                              content: Text('Failed to update UPI ID.'),
+                            ),
+                          );
+                        });
+                  },
+                  child: const Text('Save UPI'),
+                ),
               ),
-            );
-          },
+            ],
+          ),
         );
       },
     );
@@ -707,35 +1625,144 @@ class _PayoutsScreenState extends State<PayoutsScreen> {
     controller.dispose();
   }
 
-  Widget _buildReceiptActions() {
-    return SizedBox(
-      width: double.infinity,
-      child: ElevatedButton.icon(
-        onPressed: () => _showSimpleInfo('Receipt download will be added next'),
-        icon: const Icon(Icons.download_rounded, size: 30, color: Colors.white),
-        label: const Text(
-          'Download receipt',
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w700,
-            color: Colors.white,
-          ),
-        ),
-        style: ElevatedButton.styleFrom(
-          backgroundColor: AppColors.primary,
-          foregroundColor: Colors.white,
-          minimumSize: const Size.fromHeight(56),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(14),
-          ),
-          elevation: 0,
-        ),
+  Future<void> _verifyPrimary() async {
+    try {
+      await _apiService.verifyPayoutAccount('primary');
+      await _refreshPayouts();
+      if (!mounted) return;
+      _showSimpleInfo('Primary UPI verified');
+    } catch (_) {
+      if (!mounted) return;
+      _showSimpleInfo('Primary UPI verification failed');
+    }
+  }
+
+  Future<void> _verifyBackup() async {
+    try {
+      await _apiService.verifyPayoutAccount('backup');
+      await _refreshPayouts();
+      if (!mounted) return;
+      _showSimpleInfo('Backup UPI verified');
+    } catch (_) {
+      if (!mounted) return;
+      _showSimpleInfo('Backup UPI verification failed');
+    }
+  }
+
+  Future<void> _showCurrentMonthStatement() async {
+    final now = DateTime.now();
+    try {
+      final statement = await _apiService.getPayoutStatement(
+        startDate: DateTime(now.year, now.month, 1),
+        endDate: now,
+      );
+      if (!mounted) return;
+      await _showStatementSheet(statement);
+    } catch (_) {
+      if (!mounted) return;
+      _showSimpleInfo('Failed to generate monthly statement');
+    }
+  }
+
+  Future<void> _pickCustomRange(BuildContext context) async {
+    final now = DateTime.now();
+    final range = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime(now.year - 2),
+      lastDate: now,
+      initialDateRange: DateTimeRange(
+        start: DateTime(now.year, now.month, 1),
+        end: now,
       ),
+    );
+    if (range == null) return;
+    try {
+      final statement = await _apiService.getPayoutStatement(
+        startDate: range.start,
+        endDate: range.end,
+      );
+      if (!mounted) return;
+      await _showStatementSheet(statement);
+    } catch (_) {
+      if (!mounted) return;
+      _showSimpleInfo('Failed to generate statement');
+    }
+  }
+
+  Future<void> _showStatementSheet(Map<String, dynamic> statement) {
+    return showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (_) {
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Statement ready',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                "Transfers: ${statement['transferCount']}  Total: Rs ${statement['totalAmount']}",
+              ),
+              const SizedBox(height: 12),
+              SelectableText(
+                _coerceString(statement['csv']),
+                style: const TextStyle(fontSize: 12),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 
   void _showSimpleInfo(String message) {
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _showTransferReceipt(_PayoutEntry entry) {
+    return showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (_) {
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Transfer receipt',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 10),
+              Text('Trigger: ${entry.triggerType}'),
+              Text('Amount: ₹${_currencyFormat.format(entry.amount)}'),
+              Text('Date: ${_dateFormat.format(entry.date)}'),
+              Text('Reference: ${entry.upiRef}'),
+              const SizedBox(height: 14),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    _showSimpleInfo('Receipt queued for download');
+                  },
+                  icon: const Icon(Icons.download_outlined),
+                  label: const Text('Download PDF Receipt'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   void _switchToTab(int index) {
@@ -745,205 +1772,171 @@ class _PayoutsScreenState extends State<PayoutsScreen> {
 
   void _openHome() => _switchToTab(0);
 
-  String _formatTimeLabel(DateTime value) => _timeFormat.format(value);
+  void _showAccountSheet(User user) {
+    final safeName = _coerceString(user.name, fallback: 'User');
+    final safePhone = _coerceString(user.phone, fallback: 'No phone on file');
 
-  Future<void> _onCustomRangeTap() async {
-    final now = DateTime.now();
-    final picked = await showDateRangePicker(
+    showModalBottomSheet<void>(
       context: context,
-      firstDate: DateTime(now.year - 5),
-      lastDate: now,
-      initialDateRange: _customDateRange ??
-          DateTimeRange(
-            start: DateTime(now.year, now.month, 1),
-            end: now,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: CircleAvatar(
+                  backgroundColor: AppColors.primary,
+                  child: Text(
+                    _userInitials(safeName).substring(0, 1),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                title: Text(safeName),
+                subtitle: Text(safePhone),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _switchToTab(4);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.home_outlined),
+                title: const Text('Home'),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _switchToTab(0);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.receipt_long_outlined),
+                title: const Text('Claims'),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _switchToTab(1);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.shield_outlined),
+                title: const Text('Coverage details'),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _switchToTab(2);
+                },
+              ),
+            ],
           ),
+        );
+      },
     );
-
-    if (picked == null || !mounted) return;
-    setState(() {
-      _customDateRange = picked;
-      _selectedRange = 3;
-    });
-  }
-
-  String _customRangePillLabel() {
-    final range = _customDateRange;
-    if (range == null) return 'Custom';
-    return '${_formatDayMonth(range.start)} - ${_formatDayMonth(range.end)}';
-  }
-
-    int _totalReceivedForRange(int range) {
-    return _payouts
-      .where((entry) => _isInRange(entry.date, range) && _isSettled(entry))
-        .fold<int>(0, (sum, entry) => sum + entry.amount);
-  }
-
-    List<_PayoutEntry> _settledPayoutsForRange(int range) {
-    final settled = _payouts
-      .where((entry) => _isSettled(entry) && _isInRange(entry.date, range))
-        .toList();
-    settled.sort((a, b) => b.date.compareTo(a.date));
-    return settled;
-  }
-
-  bool _isSettled(_PayoutEntry entry) {
-    return entry.status.toLowerCase() == 'settled';
-  }
-
-  String _claimLabel(_PayoutEntry entry) {
-    final label = _coerceString(entry.triggerType);
-    if (label.isEmpty) return 'Claim payout';
-    return label;
-  }
-
-  bool _isInRange(DateTime value, int range) {
-    if (range == 2) return true;
-    if (range == 3) {
-      final selected = _customDateRange;
-      if (selected == null) return false;
-      final day = DateTime(value.year, value.month, value.day);
-      final start = DateTime(selected.start.year, selected.start.month, selected.start.day);
-      final end = DateTime(selected.end.year, selected.end.month, selected.end.day);
-      return !day.isBefore(start) && !day.isAfter(end);
-    }
-
-    final now = DateTime.now();
-    final thisWeekStart = DateTime(now.year, now.month, now.day)
-        .subtract(Duration(days: now.weekday - 1));
-    final targetStart = thisWeekStart.subtract(Duration(days: 7 * range));
-    final targetEnd = targetStart.add(const Duration(days: 7));
-    final day = DateTime(value.year, value.month, value.day);
-    return !day.isBefore(targetStart) && day.isBefore(targetEnd);
-  }
-
-  String _rangeLabel(int range) {
-    if (range == 1) return 'Previous week';
-    if (range == 2) return 'All time';
-    if (range == 3) {
-      final selected = _customDateRange;
-      if (selected == null) return 'Custom range';
-      return '${_formatDayMonth(selected.start)} - ${_formatDayMonth(selected.end)}';
-    }
-    return 'This week';
-  }
-
-  String _rangeTitle(int range) {
-    if (range == 1) return 'Savings for Previous Week';
-    if (range == 2) return 'Savings Since Joining';
-    if (range == 3) return 'Total Savings';
-    return 'Savings for This Week';
-  }
-
-  String _recentCreditedUpi(_PayoutEntry? latestPayout) {
-    final fromTransfer = _coerceString(latestPayout?.upiId);
-    if (fromTransfer.isNotEmpty) return fromTransfer;
-    if (_primaryUpi.isNotEmpty) return _primaryUpi;
-    return '9876543210@okaxis';
-  }
-
-  String _coerceString(Object? value, {String fallback = ''}) {
-    if (value == null) return fallback;
-    final text = value.toString().trim();
-    return text.isEmpty ? fallback : text;
-  }
-
-  String _formatDayMonth(DateTime value) {
-    const monthAbbr = <String>[
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    final month = (value.month >= 1 && value.month <= 12)
-        ? monthAbbr[value.month - 1]
-        : '---';
-    return '${value.day} $month';
   }
 }
+
+// ─── Data models ──────────────────────────────────────────────────────────────
 
 class _PayoutEntry {
   const _PayoutEntry({
     required this.date,
     required this.triggerType,
     required this.triggerRawType,
-    required this.status,
     required this.amount,
     required this.upiRef,
-    required this.upiId,
   });
 
   final DateTime date;
   final String triggerType;
   final String triggerRawType;
-  final String status;
   final int amount;
   final String upiRef;
-  final String upiId;
 }
 
-class _ReceiptStep {
-  const _ReceiptStep({required this.title, required this.subtitle});
+class _MonthlySummary {
+  const _MonthlySummary({
+    required this.totalReceived,
+    required this.count,
+    required this.average,
+  });
 
-  final String title;
-  final String subtitle;
+  final int totalReceived;
+  final int count;
+  final int average;
 }
 
 class _PayoutsTopBackgroundPainter extends CustomPainter {
-  const _PayoutsTopBackgroundPainter();
+  const _PayoutsTopBackgroundPainter({required this.isDark});
+
+  final bool isDark;
 
   @override
   void paint(Canvas canvas, Size size) {
-    final base = Paint()
-      ..shader = const LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [
-          AppColors.accentLight,
-          Color(0xFFD7F3EF),
-          Color(0xFFF4FBF9),
-        ],
+    final backgroundPaint = Paint()
+      ..shader = LinearGradient(
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+        colors: isDark
+            ? <Color>[
+                AppColors.nightSurface,
+                AppColors.nightSurfaceElevated,
+                AppColors.nightBackground,
+              ]
+            : <Color>[
+                const Color(0xFFF4F8F5),
+                const Color(0xFFEDF4F0),
+                const Color(0xFFE7EFEA),
+              ],
       ).createShader(Rect.fromLTWH(0, 0, size.width, size.height));
 
-    final basePath = Path()
-      ..moveTo(0, 0)
-      ..lineTo(size.width, 0)
-      ..lineTo(size.width, size.height * 0.86)
-      ..lineTo(size.width * 0.68, size.height * 0.78)
-      ..lineTo(size.width * 0.32, size.height * 0.94)
-      ..lineTo(0, size.height * 0.82)
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, size.width, size.height),
+      backgroundPaint,
+    );
+
+    final accentPaint = Paint()
+      ..color = (isDark ? AppColors.neonGreen : AppColors.primary).withValues(
+        alpha: 0.08,
+      )
+      ..style = PaintingStyle.fill;
+
+    canvas.drawCircle(
+      Offset(size.width * 0.12, size.height * 0.22),
+      54,
+      accentPaint,
+    );
+    canvas.drawCircle(
+      Offset(size.width * 0.84, size.height * 0.26),
+      34,
+      accentPaint,
+    );
+
+    final curvePaint = Paint()
+      ..color = (isDark ? AppColors.nightBorder : Colors.white).withValues(
+        alpha: isDark ? 0.60 : 0.4,
+      );
+    final curvePath = Path()
+      ..moveTo(0, size.height * 0.72)
+      ..cubicTo(
+        size.width * 0.16,
+        size.height * 0.60,
+        size.width * 0.34,
+        size.height * 0.84,
+        size.width * 0.52,
+        size.height * 0.72,
+      )
+      ..cubicTo(
+        size.width * 0.70,
+        size.height * 0.60,
+        size.width * 0.84,
+        size.height * 0.80,
+        size.width,
+        size.height * 0.70,
+      )
+      ..lineTo(size.width, size.height)
+      ..lineTo(0, size.height)
       ..close();
 
-    canvas.drawPath(basePath, base);
-
-    final stripePaint = Paint()
-      ..color = AppColors.primary.withValues(alpha: 0.08)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.2;
-
-    canvas.drawLine(
-      Offset(size.width * 0.08, size.height * 0.22),
-      Offset(size.width * 0.92, size.height * 0.42),
-      stripePaint,
-    );
-    canvas.drawLine(
-      Offset(size.width * 0.02, size.height * 0.38),
-      Offset(size.width * 0.74, size.height * 0.64),
-      stripePaint,
-    );
-
-    final dotPaint = Paint()..color = AppColors.accent.withValues(alpha: 0.18);
-    canvas.drawCircle(Offset(size.width * 0.15, size.height * 0.12), 12, dotPaint);
-    canvas.drawCircle(Offset(size.width * 0.82, size.height * 0.2), 20, dotPaint);
-    canvas.drawCircle(Offset(size.width * 0.58, size.height * 0.72), 10, dotPaint);
+    canvas.drawPath(curvePath, curvePaint);
   }
 
   @override

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -7,6 +7,7 @@ import '../../routes/app_routes.dart';
 import '../../services/api_service.dart';
 import '../../services/tab_router.dart';
 import '../../theme/app_colors.dart';
+import '../../theme/theme_controller.dart';
 
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
@@ -39,23 +40,30 @@ class ProfileScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final pageBackground = isDark
+        ? AppColors.nightBackground
+        : AppColors.scaffoldBackground;
+
     return FutureBuilder<_ProfileViewData>(
       future: _loadProfileViewData(),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Scaffold(
-            backgroundColor: AppColors.scaffoldBackground,
+          return Scaffold(
+            backgroundColor: pageBackground,
             body: Center(child: CircularProgressIndicator()),
           );
         }
 
         if (snapshot.hasError || snapshot.data == null) {
-          return const Scaffold(
-            backgroundColor: AppColors.scaffoldBackground,
+          return Scaffold(
+            backgroundColor: pageBackground,
             body: Center(
               child: Text(
                 'Could not load settings. Please retry.',
-                style: TextStyle(color: AppColors.textSecondary),
+                style: TextStyle(
+                  color: isDark ? Colors.white70 : AppColors.textSecondary,
+                ),
               ),
             ),
           );
@@ -68,36 +76,41 @@ class ProfileScreen extends StatelessWidget {
         final payoutDashboard = data.payoutDashboard;
         final claimCountThisMonth = _claimCountForCurrentMonth(claims);
         final perTriggerPayout = _readInt(policy, const ['perTriggerPayout']);
-        final activePlan = _readString(policy, const ['plan'], fallback: user.plan);
         final weeklyPremium = _readInt(policy, const ['weeklyPremium']);
-        final nextBillingDate = _readString(policy, const ['nextBillingDate']);
-        final renewalLabel = _renewalLabel(nextBillingDate);
-        final policyStatus = _readString(policy, const ['status'], fallback: 'active').toLowerCase();
+        final activePlan = _readString(policy, const [
+          'plan',
+        ], fallback: user.plan);
+        final locationLabel = _buildLocationLabel(user);
+        final policyStatus = _readString(policy, const [
+          'status',
+        ], fallback: 'active').toLowerCase();
         final statusLabel = policyStatus == 'active'
-          ? 'Active policy'
-          : policyStatus == 'scheduled'
+            ? 'Active policy'
+            : policyStatus == 'scheduled'
             ? 'Plan change scheduled'
             : 'Policy update pending';
+        final nextBillingDate = _readString(policy, const ['nextBillingDate']);
+        final renewalLabel = _renewalLabel(nextBillingDate);
         final payoutSummary = _readMap(payoutDashboard, const ['summary']);
         final settledTotal = _readDouble(payoutSummary, const ['settledTotal']);
         final pendingTotal = _readDouble(payoutSummary, const ['pendingTotal']);
-        final primaryUpiMasked = _readString(payoutDashboard, const ['primaryUpiMasked']);
+        final primaryUpiMasked = _readString(payoutDashboard, const [
+          'primaryUpiMasked',
+        ]);
         final provider = _readString(payoutDashboard, const ['provider']);
-        final notificationItems = _buildNotificationItems(policy);
-        final supportItems = _buildSupportItems(policy);
-
+        final contact = _formatPhone(user.phone);
         return Scaffold(
-          backgroundColor: AppColors.scaffoldBackground,
+          backgroundColor: pageBackground,
           body: Stack(
             children: [
-              const Positioned(
+              Positioned(
                 top: 0,
                 left: 0,
                 right: 0,
                 child: SizedBox(
                   height: 205,
                   child: CustomPaint(
-                    painter: _ProfileTopBackgroundPainter(),
+                    painter: _ProfileTopBackgroundPainter(isDark: isDark),
                   ),
                 ),
               ),
@@ -107,33 +120,43 @@ class ProfileScreen extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      _buildTopUtilityButtons(context, notificationItems),
+                      _buildTopUtilityButtons(context),
                       const SizedBox(height: 14),
-                      const Text(
+                      Text(
                         'Settings',
                         style: TextStyle(
                           fontSize: 30,
                           fontWeight: FontWeight.w800,
-                          color: AppColors.textPrimary,
+                          color: isDark ? Colors.white : AppColors.textPrimary,
                           letterSpacing: -0.4,
                         ),
                       ),
                       const SizedBox(height: 6),
-                      const Text(
+                      Text(
                         'Manage your profile, coverage, and payouts.',
                         style: TextStyle(
                           fontSize: 13,
-                          color: AppColors.textSecondary,
+                          color: isDark
+                              ? Colors.white70
+                              : AppColors.textSecondary,
                         ),
                       ),
                       const SizedBox(height: 16),
+                      _buildHeader(
+                        context,
+                        user,
+                        contact,
+                        statusLabel,
+                        locationLabel,
+                      ),
                       _buildCoverageBanner(
+                        context: context,
                         perTriggerPayout: perTriggerPayout,
                         activePlan: activePlan,
                         renewalLabel: renewalLabel,
                       ),
-                      _buildSectionLabel('Insurance'),
-                      _buildMenuGroup([
+                      _buildSectionLabel(context, 'Insurance'),
+                      _buildMenuGroup(context, [
                         _MenuItemData(
                           icon: Icons.receipt_long_outlined,
                           iconBg: const Color(0xFFE1F5EE),
@@ -160,21 +183,25 @@ class ProfileScreen extends StatelessWidget {
                           subtitle: activePlan.trim().isEmpty
                               ? 'Check available plans'
                               : weeklyPremium > 0
-                                  ? '$activePlan • ₹${NumberFormat('#,##0').format(weeklyPremium)}/week'
-                                  : '$activePlan plan active',
+                              ? '$activePlan • ₹${NumberFormat('#,##0').format(weeklyPremium)}/week'
+                              : '$activePlan plan active',
                           onTap: () => _switchToTab(context, 2),
                         ),
                       ]),
-                      _buildSectionLabel('Preferences'),
-                      _buildMenuGroup([
+                      _buildSectionLabel(context, 'Preferences'),
+                      _buildMenuGroup(context, [
                         _MenuItemData(
                           icon: Icons.payments_outlined,
                           iconBg: const Color(0xFFE1F5EE),
                           iconColor: const Color(0xFF0F6E56),
                           title: 'Payout settings',
                           subtitle: primaryUpiMasked.isNotEmpty
-                              ? (provider.isNotEmpty ? '$provider • $primaryUpiMasked' : primaryUpiMasked)
-                              : (provider.isNotEmpty ? provider : 'No payout account returned'),
+                              ? (provider.isNotEmpty
+                                    ? '$provider • $primaryUpiMasked'
+                                    : primaryUpiMasked)
+                              : (provider.isNotEmpty
+                                    ? provider
+                                    : 'No payout account returned'),
                           onTap: () => _switchToTab(context, 3),
                         ),
                         _MenuItemData(
@@ -190,12 +217,20 @@ class ProfileScreen extends StatelessWidget {
                           iconBg: const Color(0xFFE1F5EE),
                           iconColor: const Color(0xFF0F6E56),
                           title: 'Help and support',
-                          subtitle: supportItems.isEmpty ? null : '${supportItems.length} live support entries',
-                          onTap: () => _showSupportSheet(context, supportItems),
+                          subtitle: 'Contact help and review claim guidance',
+                          onTap: () => _showSupportSheet(context),
+                        ),
+                        _MenuItemData(
+                          icon: Icons.contrast_rounded,
+                          iconBg: const Color(0xFFE8EEFF),
+                          iconColor: const Color(0xFF2C4DAA),
+                          title: 'Appearance mode',
+                          subtitle: _themeSubtitle(),
+                          onTap: () => _showThemeModeSheet(context),
                         ),
                       ]),
-                      _buildSectionLabel('Account'),
-                      _buildMenuGroup([
+                      _buildSectionLabel(context, 'Account'),
+                      _buildMenuGroup(context, [
                         _MenuItemData(
                           icon: Icons.logout,
                           iconBg: const Color(0xFFFCEBEB),
@@ -244,7 +279,10 @@ class ProfileScreen extends StatelessWidget {
                 decoration: BoxDecoration(
                   color: Colors.white,
                   shape: BoxShape.circle,
-                  border: Border.all(color: Colors.white.withValues(alpha: 0.4), width: 2),
+                  border: Border.all(
+                    color: Colors.white.withValues(alpha: 0.4),
+                    width: 2,
+                  ),
                 ),
                 child: Center(
                   child: Text(
@@ -297,8 +335,14 @@ class ProfileScreen extends StatelessWidget {
             spacing: 8,
             runSpacing: 8,
             children: [
-              _statusPill(dotColor: const Color(0xFF6EFFC4), label: policyStatus),
-              _statusPill(dotColor: const Color(0xFFFFD980), label: locationLabel),
+              _statusPill(
+                dotColor: const Color(0xFF6EFFC4),
+                label: policyStatus,
+              ),
+              _statusPill(
+                dotColor: const Color(0xFFFFD980),
+                label: locationLabel,
+              ),
             ],
           ),
         ],
@@ -306,10 +350,7 @@ class ProfileScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildTopUtilityButtons(
-    BuildContext context,
-    List<_SheetItemData> notificationItems,
-  ) {
+  Widget _buildTopUtilityButtons(BuildContext context) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -319,7 +360,7 @@ class ProfileScreen extends StatelessWidget {
         ),
         _headerIconButton(
           icon: Icons.notifications_none,
-          onTap: () => _showNotificationsSheet(context, notificationItems),
+          onTap: () => _showNotificationsSheet(context),
         ),
       ],
     );
@@ -338,8 +379,7 @@ class ProfileScreen extends StatelessWidget {
         decoration: BoxDecoration(
           color: Colors.white.withValues(alpha: 0.15),
           borderRadius: BorderRadius.circular(10),
-          border:
-              Border.all(color: Colors.white.withValues(alpha: 0.2)),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.2)),
         ),
         child: Icon(icon, size: 20, color: Colors.white),
       ),
@@ -351,13 +391,11 @@ class ProfileScreen extends StatelessWidget {
       borderRadius: BorderRadius.circular(8),
       onTap: () => _showProfileDetailsSheet(context, user, contact),
       child: Container(
-        padding:
-            const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
         decoration: BoxDecoration(
           color: Colors.white.withValues(alpha: 0.18),
           borderRadius: BorderRadius.circular(8),
-          border:
-              Border.all(color: Colors.white.withValues(alpha: 0.25)),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.25)),
         ),
         child: const Text(
           'Details',
@@ -371,18 +409,14 @@ class ProfileScreen extends StatelessWidget {
     );
   }
 
-  Widget _statusPill({
-    required Color dotColor,
-    required String label,
-  }) {
+  Widget _statusPill({required Color dotColor, required String label}) {
     return Container(
       constraints: const BoxConstraints(maxWidth: 220),
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
       decoration: BoxDecoration(
         color: Colors.white.withValues(alpha: 0.15),
         borderRadius: BorderRadius.circular(99),
-        border:
-            Border.all(color: Colors.white.withValues(alpha: 0.2)),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.2)),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -390,10 +424,7 @@ class ProfileScreen extends StatelessWidget {
           Container(
             width: 6,
             height: 6,
-            decoration: BoxDecoration(
-              color: dotColor,
-              shape: BoxShape.circle,
-            ),
+            decoration: BoxDecoration(color: dotColor, shape: BoxShape.circle),
           ),
           const SizedBox(width: 5),
           Flexible(
@@ -416,17 +447,24 @@ class ProfileScreen extends StatelessWidget {
   // ─── Coverage banner ───────────────────────────────────────────────────────
 
   Widget _buildCoverageBanner({
+    required BuildContext context,
     required int perTriggerPayout,
     required String activePlan,
     required String renewalLabel,
   }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surfaceColor = isDark ? AppColors.nightSurface : Colors.white;
+    final borderColor = isDark
+        ? AppColors.nightBorder
+        : const Color(0xFFE2EBE6);
+
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: surfaceColor,
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: const Color(0xFFE2EBE6)),
+        border: Border.all(color: borderColor),
       ),
       child: Row(
         children: [
@@ -467,17 +505,13 @@ class ProfileScreen extends StatelessWidget {
               const SizedBox(height: 1),
               Text(
                 renewalLabel,
-                style: TextStyle(
-                  fontSize: 10,
-                  color: Colors.grey.shade500,
-                ),
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade500),
               ),
             ],
           ),
           const Spacer(),
           Container(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
             decoration: BoxDecoration(
               color: const Color(0xFFE1F5EE),
               borderRadius: BorderRadius.circular(99),
@@ -498,15 +532,16 @@ class ProfileScreen extends StatelessWidget {
 
   // ─── Section label ─────────────────────────────────────────────────────────
 
-  Widget _buildSectionLabel(String label) {
+  Widget _buildSectionLabel(BuildContext context, String label) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 8),
       child: Text(
         label.toUpperCase(),
-        style: const TextStyle(
+        style: TextStyle(
           fontSize: 11,
           fontWeight: FontWeight.w700,
-          color: Color(0xFF8BA897),
+          color: isDark ? Colors.white70 : const Color(0xFF8BA897),
           letterSpacing: 0.08 * 11,
         ),
       ),
@@ -515,26 +550,35 @@ class ProfileScreen extends StatelessWidget {
 
   // ─── Menu group ────────────────────────────────────────────────────────────
 
-  Widget _buildMenuGroup(List<_MenuItemData> items) {
+  Widget _buildMenuGroup(BuildContext context, List<_MenuItemData> items) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surfaceColor = isDark ? AppColors.nightSurface : Colors.white;
+    final borderColor = isDark
+        ? AppColors.nightBorder
+        : const Color(0xFFE2EBE6);
+    final dividerColor = isDark
+        ? AppColors.nightBorder
+        : const Color(0xFFE8F0EB);
+
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: surfaceColor,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: const Color(0xFFE2EBE6)),
+        border: Border.all(color: borderColor),
       ),
       clipBehavior: Clip.hardEdge,
       child: Column(
         children: List.generate(items.length, (i) {
           return Column(
             children: [
-              _buildMenuRow(items[i]),
+              _buildMenuRow(context, items[i]),
               if (i < items.length - 1)
-                const Divider(
+                Divider(
                   height: 0,
                   thickness: 0.5,
                   indent: 56,
-                  color: Color(0xFFE8F0EB),
+                  color: dividerColor,
                 ),
             ],
           );
@@ -543,7 +587,7 @@ class ProfileScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildMenuRow(_MenuItemData item) {
+  Widget _buildMenuRow(BuildContext context, _MenuItemData item) {
     return InkWell(
       onTap: item.onTap,
       child: Padding(
@@ -569,16 +613,18 @@ class ProfileScreen extends StatelessWidget {
                     style: TextStyle(
                       fontSize: 15,
                       fontWeight: FontWeight.w600,
-                      color: item.titleColor ?? const Color(0xFF1A2E25),
+                      color:
+                          item.titleColor ??
+                          Theme.of(context).colorScheme.onSurface,
                     ),
                   ),
                   if (item.subtitle != null) ...[
                     const SizedBox(height: 1),
                     Text(
                       item.subtitle!,
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 11,
-                        color: Color(0xFF8BA897),
+                        color: Theme.of(context).textTheme.bodySmall?.color,
                       ),
                     ),
                   ],
@@ -587,8 +633,7 @@ class ProfileScreen extends StatelessWidget {
             ),
             if (item.badge != null) ...[
               Container(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 8, vertical: 3),
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
                 decoration: BoxDecoration(
                   color: const Color(0xFFE1F5EE),
                   borderRadius: BorderRadius.circular(99),
@@ -604,11 +649,7 @@ class ProfileScreen extends StatelessWidget {
               ),
               const SizedBox(width: 6),
             ],
-            const Icon(
-              Icons.chevron_right,
-              size: 18,
-              color: Color(0xFFB0C4B8),
-            ),
+            const Icon(Icons.chevron_right, size: 18, color: Color(0xFFB0C4B8)),
           ],
         ),
       ),
@@ -617,7 +658,7 @@ class ProfileScreen extends StatelessWidget {
 
   // ─── Actions ───────────────────────────────────────────────────────────────
 
-  void _showNotificationsSheet(BuildContext context, List<_SheetItemData> items) {
+  void _showNotificationsSheet(BuildContext context) {
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
@@ -625,21 +666,28 @@ class ProfileScreen extends StatelessWidget {
         return ListView(
           shrinkWrap: true,
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
-          children: items
-              .map(
-                (item) => ListTile(
-                  leading: Icon(item.icon),
-                  title: Text(item.title),
-                  subtitle: Text(item.subtitle),
-                ),
-              )
-              .toList(),
+          children: const [
+            ListTile(
+              leading: Icon(Icons.verified_outlined),
+              title: Text('Profile verification completed'),
+              subtitle: Text('Your account details are fully up to date'),
+            ),
+            ListTile(
+              leading: Icon(Icons.shield_outlined),
+              title: Text('Security reminder'),
+              subtitle: Text('Review device activity once every week'),
+            ),
+          ],
         );
       },
     );
   }
 
-  void _showProfileDetailsSheet(BuildContext context, User user, String contact) {
+  void _showProfileDetailsSheet(
+    BuildContext context,
+    User user,
+    String contact,
+  ) {
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
@@ -663,13 +711,21 @@ class ProfileScreen extends StatelessWidget {
               contentPadding: EdgeInsets.zero,
               leading: const Icon(Icons.location_on_outlined),
               title: Text(user.zone.isEmpty ? 'Zone unavailable' : user.zone),
-              subtitle: Text(user.zonePincode.isEmpty ? 'Pincode unavailable' : user.zonePincode),
+              subtitle: Text(
+                user.zonePincode.isEmpty
+                    ? 'Pincode unavailable'
+                    : user.zonePincode,
+              ),
             ),
             ListTile(
               contentPadding: EdgeInsets.zero,
               leading: const Icon(Icons.local_shipping_outlined),
-              title: Text(user.platform.isEmpty ? 'Platform unavailable' : user.platform),
-              subtitle: Text(user.plan.isEmpty ? 'Plan unavailable' : '${user.plan} plan'),
+              title: Text(
+                user.platform.isEmpty ? 'Platform unavailable' : user.platform,
+              ),
+              subtitle: Text(
+                user.plan.isEmpty ? 'Plan unavailable' : '${user.plan} plan',
+              ),
             ),
           ],
         );
@@ -677,7 +733,7 @@ class ProfileScreen extends StatelessWidget {
     );
   }
 
-  void _showSupportSheet(BuildContext context, List<_SheetItemData> items) {
+  void _showSupportSheet(BuildContext context) {
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
@@ -685,147 +741,120 @@ class ProfileScreen extends StatelessWidget {
         return ListView(
           shrinkWrap: true,
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
-          children: [
+          children: const [
             Text(
               'Help and support',
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
             ),
             SizedBox(height: 12),
-            ...items
-                .map(
-                  (item) => ListTile(
-                    contentPadding: EdgeInsets.zero,
-                    leading: Icon(item.icon),
-                    title: Text(item.title),
-                    subtitle: Text(item.subtitle),
-                  ),
-                )
-                .toList(),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.call_outlined),
+              title: Text('Claims helpline'),
+              subtitle: Text('+91 1800 00 0000'),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.mail_outline),
+              title: Text('Support email'),
+              subtitle: Text('support@saatdin.in'),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.rule_folder_outlined),
+              title: Text('Escalation timeline'),
+              subtitle: Text('Manual escalations are reviewed within 2 hours.'),
+            ),
           ],
         );
       },
     );
   }
 
-  List<_SheetItemData> _buildNotificationItems(Map<String, dynamic> policy) {
-    final rawItems = _readMapList(policy, const ['notifications', 'notificationItems']);
-    return rawItems
-        .map((item) {
-          final title = _readString(item, const ['title', 'heading']);
-          final subtitle = _readString(item, const ['subtitle', 'message', 'description']);
-          if (title.isEmpty || subtitle.isEmpty) return null;
-          return _SheetItemData(
-            icon: _iconFromName(_readString(item, const ['icon', 'iconName'])),
-            title: title,
-            subtitle: subtitle,
-          );
-        })
-        .whereType<_SheetItemData>()
-        .toList();
-  }
-
-  List<_SheetItemData> _buildSupportItems(Map<String, dynamic> policy) {
-    final support = _readMap(policy, const ['support']);
-    final items = <_SheetItemData>[];
-
-    final helpline = _readString(support, const ['helpline', 'phone']);
-    final email = _readString(support, const ['email', 'supportEmail']);
-    final timeline = _readString(support, const ['escalationTimeline', 'timeline']);
-
-    if (helpline.isNotEmpty) {
-      items.add(
-        _SheetItemData(
-          icon: Icons.call_outlined,
-          title: 'Claims helpline',
-          subtitle: helpline,
-        ),
-      );
-    }
-    if (email.isNotEmpty) {
-      items.add(
-        _SheetItemData(
-          icon: Icons.mail_outline,
-          title: 'Support email',
-          subtitle: email,
-        ),
-      );
-    }
-    if (timeline.isNotEmpty) {
-      items.add(
-        _SheetItemData(
-          icon: Icons.rule_folder_outlined,
-          title: 'Escalation timeline',
-          subtitle: timeline,
-        ),
-      );
-    }
-
-    final supportItems = _readMapList(support, const ['items']);
-    for (final item in supportItems) {
-      final title = _readString(item, const ['title', 'heading']);
-      final subtitle = _readString(item, const ['subtitle', 'message', 'description']);
-      if (title.isEmpty || subtitle.isEmpty) continue;
-      items.add(
-        _SheetItemData(
-          icon: _iconFromName(_readString(item, const ['icon', 'iconName'])),
-          title: title,
-          subtitle: subtitle,
-        ),
-      );
-    }
-
-    return items;
-  }
-
-  Map<String, dynamic> _readMap(Map<String, dynamic> raw, List<String> keys) {
-    for (final key in keys) {
-      final value = raw[key];
-      if (value is Map<String, dynamic>) return value;
-    }
-    return <String, dynamic>{};
-  }
-
-  List<Map<String, dynamic>> _readMapList(Map<String, dynamic> raw, List<String> keys) {
-    for (final key in keys) {
-      final value = raw[key];
-      if (value is List) {
-        return value.whereType<Map<String, dynamic>>().toList();
-      }
-    }
-    return const <Map<String, dynamic>>[];
-  }
-
-  IconData _iconFromName(String iconName) {
-    switch (iconName.trim().toLowerCase()) {
-      case 'verified':
-      case 'check':
-        return Icons.verified_outlined;
-      case 'shield':
-      case 'security':
-        return Icons.shield_outlined;
-      case 'call':
-      case 'phone':
-        return Icons.call_outlined;
-      case 'mail':
-      case 'email':
-        return Icons.mail_outline;
-      case 'timeline':
-      case 'rules':
-        return Icons.rule_folder_outlined;
-      default:
-        return Icons.info_outline;
-    }
-  }
-
   void _showSimpleInfo(BuildContext context, String message) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message)),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   void _switchToTab(BuildContext context, int index) {
     TabRouter.switchTo(index);
     Navigator.of(context).popUntil((route) => route.isFirst);
+  }
+
+  Future<void> _showThemeModeSheet(BuildContext context) async {
+    final mode = ThemeController.instance.themeMode;
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (_) {
+        return ListView(
+          shrinkWrap: true,
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
+          children: [
+            const Text(
+              'Appearance mode',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 12),
+            _themeModeTile(
+              context: context,
+              title: 'Dark',
+              subtitle: 'Best for low light and rider dashboard mode',
+              selected: mode == ThemeMode.dark,
+              onTap: () =>
+                  ThemeController.instance.setThemeMode(ThemeMode.dark),
+            ),
+            _themeModeTile(
+              context: context,
+              title: 'Light',
+              subtitle: 'High contrast daytime theme',
+              selected: mode == ThemeMode.light,
+              onTap: () =>
+                  ThemeController.instance.setThemeMode(ThemeMode.light),
+            ),
+            _themeModeTile(
+              context: context,
+              title: 'System',
+              subtitle: 'Follow your device setting automatically',
+              selected: mode == ThemeMode.system,
+              onTap: () =>
+                  ThemeController.instance.setThemeMode(ThemeMode.system),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _themeModeTile({
+    required BuildContext context,
+    required String title,
+    required String subtitle,
+    required bool selected,
+    required VoidCallback onTap,
+  }) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: Icon(
+        selected ? Icons.radio_button_checked : Icons.radio_button_off,
+      ),
+      title: Text(title),
+      subtitle: Text(subtitle),
+      onTap: () {
+        onTap();
+        Navigator.of(context).pop();
+      },
+    );
+  }
+
+  String _themeSubtitle() {
+    final mode = ThemeController.instance.themeMode;
+    return switch (mode) {
+      ThemeMode.dark => 'Currently Dark',
+      ThemeMode.light => 'Currently Light',
+      ThemeMode.system => 'Following System',
+    };
   }
 
   void _confirmLogout(BuildContext context) {
@@ -835,7 +864,8 @@ class ProfileScreen extends StatelessWidget {
         return AlertDialog(
           title: const Text('Log out'),
           content: const Text(
-              'Are you sure you want to log out of this account?'),
+            'Are you sure you want to log out of this account?',
+          ),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(dialogContext),
@@ -904,6 +934,14 @@ class ProfileScreen extends StatelessWidget {
       }
     }
     return fallback;
+  }
+
+  Map<String, dynamic> _readMap(Map<String, dynamic> raw, List<String> keys) {
+    for (final key in keys) {
+      final value = raw[key];
+      if (value is Map<String, dynamic>) return value;
+    }
+    return <String, dynamic>{};
   }
 
   int _claimCountForCurrentMonth(List<Claim> claims) {
@@ -980,18 +1018,6 @@ class _MenuItemData {
   });
 }
 
-class _SheetItemData {
-  final IconData icon;
-  final String title;
-  final String subtitle;
-
-  const _SheetItemData({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-  });
-}
-
 class _ProfileViewData {
   const _ProfileViewData({
     required this.user,
@@ -1007,24 +1033,38 @@ class _ProfileViewData {
 }
 
 class _ProfileTopBackgroundPainter extends CustomPainter {
-  const _ProfileTopBackgroundPainter();
+  const _ProfileTopBackgroundPainter({required this.isDark});
+
+  final bool isDark;
 
   @override
   void paint(Canvas canvas, Size size) {
     final backgroundPaint = Paint()
-      ..shader = const LinearGradient(
+      ..shader = LinearGradient(
         begin: Alignment.topCenter,
         end: Alignment.bottomCenter,
-        colors: [
-          Color(0xFFE7F8F4),
-          Color(0xFFF1FBF8),
-          Color(0xFFF8FCFA),
-        ],
+        colors: isDark
+            ? <Color>[
+                AppColors.nightSurface,
+                AppColors.nightSurfaceElevated,
+                AppColors.nightBackground,
+              ]
+            : <Color>[
+                const Color(0xFFE7F8F4),
+                const Color(0xFFF1FBF8),
+                const Color(0xFFF8FCFA),
+              ],
       ).createShader(Rect.fromLTWH(0, 0, size.width, size.height));
 
-    canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), backgroundPaint);
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, size.width, size.height),
+      backgroundPaint,
+    );
 
-    final shapePaint = Paint()..color = AppColors.primary.withValues(alpha: 0.12);
+    final shapePaint = Paint()
+      ..color = (isDark ? AppColors.neonGreen : AppColors.primary).withValues(
+        alpha: 0.12,
+      );
     final shapePath = Path()
       ..moveTo(-20, size.height * 0.74)
       ..lineTo(size.width * 0.42, size.height * 0.56)
@@ -1037,10 +1077,20 @@ class _ProfileTopBackgroundPainter extends CustomPainter {
     final ringPaint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.5
-      ..color = AppColors.primary.withValues(alpha: 0.15);
+      ..color = (isDark ? AppColors.neonCyan : AppColors.primary).withValues(
+        alpha: 0.16,
+      );
 
-    canvas.drawCircle(Offset(size.width * 0.18, size.height * 0.2), 32, ringPaint);
-    canvas.drawCircle(Offset(size.width * 0.86, size.height * 0.3), 48, ringPaint);
+    canvas.drawCircle(
+      Offset(size.width * 0.18, size.height * 0.2),
+      32,
+      ringPaint,
+    );
+    canvas.drawCircle(
+      Offset(size.width * 0.86, size.height * 0.3),
+      48,
+      ringPaint,
+    );
   }
 
   @override

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -859,12 +859,12 @@ class ApiService {
           uri,
           headers: _headers(authorized: true),
           body: jsonEncode({
-            if (latitude != null) 'latitude': latitude,
-            if (longitude != null) 'longitude': longitude,
-            if (accuracyMeters != null) 'accuracyMeters': accuracyMeters,
+            'latitude': ?latitude,
+            'longitude': ?longitude,
+            'accuracyMeters': ?accuracyMeters,
             if (capturedAt != null) 'capturedAt': capturedAt.toUtc().toIso8601String(),
-            if (towerMetadata != null) 'towerMetadata': towerMetadata,
-            if (motionMetadata != null) 'motionMetadata': motionMetadata,
+            'towerMetadata': ?towerMetadata,
+            'motionMetadata': ?motionMetadata,
           }),
         )
         .timeout(_timeout);

--- a/lib/services/guide_preferences.dart
+++ b/lib/services/guide_preferences.dart
@@ -1,0 +1,34 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class GuidePreferences {
+  GuidePreferences._();
+
+  static const String homeGuideSeen = 'guide_home_seen';
+  static const String claimsGuideSeen = 'guide_claims_seen';
+  static const String coverageGuideSeen = 'guide_coverage_seen';
+  static const String payoutsGuideSeen = 'guide_payouts_seen';
+
+  static const List<String> _allGuideKeys = <String>[
+    homeGuideSeen,
+    claimsGuideSeen,
+    coverageGuideSeen,
+    payoutsGuideSeen,
+  ];
+
+  static Future<bool> shouldShow(String key) async {
+    // In-app guided overlays are currently disabled.
+    return false;
+  }
+
+  static Future<void> markSeen(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(key, true);
+  }
+
+  static Future<void> resetAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    for (final key in _allGuideKeys) {
+      await prefs.setBool(key, false);
+    }
+  }
+}

--- a/lib/services/mobile_signal_bridge.dart
+++ b/lib/services/mobile_signal_bridge.dart
@@ -12,7 +12,7 @@ class MobileSignalBridge {
     try {
       final result = await _channel.invokeMethod<dynamic>('getCellInfo');
       if (result is Map) {
-        return Map<String, dynamic>.from(result as Map<dynamic, dynamic>);
+        return Map<String, dynamic>.from(result);
       }
     } catch (_) {
       return null;

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -59,4 +59,15 @@ class AppColors {
   // Bottom nav
   static const Color navActive = Color(0xFF14B890);
   static const Color navInactive = Color(0xFF7B8794);
+
+  // Rider-first dark surface palette.
+  static const Color nightBackground = Color(0xFF06090D);
+  static const Color nightSurface = Color(0xFF0D1117);
+  static const Color nightSurfaceElevated = Color(0xFF131A23);
+  static const Color nightBorder = Color(0xFF243041);
+  static const Color neonGreen = Color(0xFF58F0A9);
+  static const Color neonCyan = Color(0xFF56D7FF);
+  static const Color neonAmber = Color(0xFFFFC44D);
+  static const Color neonRed = Color(0xFFFF6A6A);
+  static const Color neonPurple = Color(0xFFB68CFF);
 }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -140,7 +140,10 @@ class AppTheme {
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
         fillColor: AppColors.background,
-        contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 20,
+          vertical: 18,
+        ),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(16),
           borderSide: const BorderSide(color: AppColors.border),
@@ -165,11 +168,118 @@ class AppTheme {
         unselectedItemColor: AppColors.navInactive,
         type: BottomNavigationBarType.fixed,
         elevation: 8,
-        selectedLabelStyle: TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
-        unselectedLabelStyle: TextStyle(fontSize: 12, fontWeight: FontWeight.w400),
+        selectedLabelStyle: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+        ),
+        unselectedLabelStyle: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w400,
+        ),
       ),
       dividerTheme: const DividerThemeData(
         color: AppColors.borderLight,
+        thickness: 1,
+      ),
+    );
+  }
+
+  static ThemeData get darkTheme {
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.dark,
+      primaryColor: AppColors.neonGreen,
+      scaffoldBackgroundColor: AppColors.nightBackground,
+      colorScheme: const ColorScheme.dark(
+        primary: AppColors.neonGreen,
+        secondary: AppColors.neonCyan,
+        surface: AppColors.nightSurface,
+        error: AppColors.neonRed,
+        onPrimary: Colors.black,
+        onSecondary: Colors.black,
+        onSurface: Colors.white,
+        onError: Colors.white,
+      ),
+      textTheme: GoogleFonts.interTextTheme(
+        ThemeData.dark().textTheme,
+      ).apply(bodyColor: Colors.white, displayColor: Colors.white),
+      appBarTheme: AppBarTheme(
+        backgroundColor: AppColors.nightSurface,
+        foregroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: false,
+        titleTextStyle: GoogleFonts.inter(
+          fontSize: 18,
+          fontWeight: FontWeight.w700,
+          color: Colors.white,
+        ),
+      ),
+      cardTheme: CardThemeData(
+        color: AppColors.nightSurface,
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: const BorderSide(color: AppColors.nightBorder, width: 1),
+        ),
+        margin: const EdgeInsets.symmetric(vertical: 6),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.neonGreen,
+          foregroundColor: Colors.black,
+          elevation: 0,
+          padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+          textStyle: GoogleFonts.inter(
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+          side: const BorderSide(color: AppColors.nightBorder, width: 1),
+          textStyle: GoogleFonts.inter(
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: AppColors.nightSurfaceElevated,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 18,
+          vertical: 16,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: const BorderSide(color: AppColors.nightBorder),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: const BorderSide(color: AppColors.nightBorder),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: const BorderSide(color: AppColors.neonGreen, width: 2),
+        ),
+      ),
+      bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+        backgroundColor: AppColors.nightSurface,
+        selectedItemColor: AppColors.neonGreen,
+        unselectedItemColor: AppColors.textTertiary,
+        type: BottomNavigationBarType.fixed,
+      ),
+      dividerTheme: const DividerThemeData(
+        color: AppColors.nightBorder,
         thickness: 1,
       ),
     );

--- a/lib/theme/theme_controller.dart
+++ b/lib/theme/theme_controller.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeController extends ChangeNotifier {
+  ThemeController._();
+
+  static final ThemeController instance = ThemeController._();
+  static const String _themeModeKey = 'app_theme_mode';
+
+  ThemeMode _themeMode = ThemeMode.light;
+
+  ThemeMode get themeMode => _themeMode;
+  bool get isDarkMode => _themeMode == ThemeMode.dark;
+
+  Future<void> initialize() async {
+    final prefs = await SharedPreferences.getInstance();
+    final saved = prefs.getString(_themeModeKey) ?? 'light';
+    _themeMode = _fromString(saved);
+    notifyListeners();
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    if (_themeMode == mode) return;
+    _themeMode = mode;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_themeModeKey, _toString(mode));
+    notifyListeners();
+  }
+
+  ThemeMode _fromString(String raw) {
+    return switch (raw) {
+      'light' => ThemeMode.light,
+      'system' => ThemeMode.system,
+      _ => ThemeMode.dark,
+    };
+  }
+
+  String _toString(ThemeMode mode) {
+    return switch (mode) {
+      ThemeMode.light => 'light',
+      ThemeMode.system => 'system',
+      ThemeMode.dark => 'dark',
+    };
+  }
+}

--- a/lib/widgets/claim_card.dart
+++ b/lib/widgets/claim_card.dart
@@ -7,24 +7,21 @@ class ClaimCard extends StatelessWidget {
   final Claim claim;
   final VoidCallback? onTap;
 
-  const ClaimCard({
-    super.key,
-    required this.claim,
-    this.onTap,
-  });
+  const ClaimCard({super.key, required this.claim, this.onTap});
 
   @override
   Widget build(BuildContext context) {
     final dateFormat = DateFormat('dd MMM');
+    final accent = claim.statusColor;
 
     return GestureDetector(
       onTap: onTap,
       child: Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: AppColors.cardBackground,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: AppColors.border, width: 1),
+          color: AppColors.nightSurface,
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: accent.withValues(alpha: 0.18), width: 1),
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -37,14 +34,10 @@ class ClaimCard extends StatelessWidget {
                   width: 40,
                   height: 40,
                   decoration: BoxDecoration(
-                    color: claim.typeColor.withValues(alpha: 0.1),
+                    color: claim.typeColor.withValues(alpha: 0.16),
                     borderRadius: BorderRadius.circular(10),
                   ),
-                  child: Icon(
-                    claim.typeIcon,
-                    color: claim.typeColor,
-                    size: 20,
-                  ),
+                  child: Icon(claim.typeIcon, color: claim.typeColor, size: 20),
                 ),
                 const SizedBox(width: 12),
                 // Claim info
@@ -59,7 +52,8 @@ class ClaimCard extends StatelessWidget {
                         style: const TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w600,
-                          color: AppColors.textPrimary,
+                          color: Colors.white,
+                          height: 1.25,
                         ),
                       ),
                       const SizedBox(height: 2),
@@ -68,7 +62,7 @@ class ClaimCard extends StatelessWidget {
                         style: const TextStyle(
                           fontSize: 11,
                           fontWeight: FontWeight.w500,
-                          color: AppColors.textTertiary,
+                          color: Colors.white70,
                           letterSpacing: 0.5,
                         ),
                       ),
@@ -84,24 +78,28 @@ class ClaimCard extends StatelessWidget {
                       style: const TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w700,
-                        color: AppColors.textPrimary,
+                        color: Colors.white,
                       ),
                     ),
                     const SizedBox(height: 4),
-                    // Status badge
                     Container(
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 3),
+                        horizontal: 8,
+                        vertical: 3,
+                      ),
                       decoration: BoxDecoration(
-                        color: claim.statusColor.withValues(alpha: 0.1),
-                        borderRadius: BorderRadius.circular(6),
+                        color: accent.withValues(alpha: 0.16),
+                        borderRadius: BorderRadius.circular(999),
+                        border: Border.all(
+                          color: accent.withValues(alpha: 0.22),
+                        ),
                       ),
                       child: Text(
                         claim.statusLabel.toUpperCase(),
                         style: TextStyle(
                           fontSize: 10,
                           fontWeight: FontWeight.w700,
-                          color: claim.statusColor,
+                          color: accent,
                           letterSpacing: 0.5,
                         ),
                       ),
@@ -110,31 +108,30 @@ class ClaimCard extends StatelessWidget {
                 ),
               ],
             ),
-            // Bank info if settled
             if (claim.bankInfo case final bankInfo?) ...[
               const SizedBox(height: 12),
               Row(
                 children: [
-                  const Icon(Icons.calendar_today,
-                      size: 12, color: AppColors.textTertiary),
+                  const Icon(
+                    Icons.calendar_today,
+                    size: 12,
+                    color: Colors.white54,
+                  ),
                   const SizedBox(width: 4),
                   Text(
                     dateFormat.format(claim.date),
-                    style: const TextStyle(
-                      fontSize: 12,
-                      color: AppColors.textTertiary,
-                    ),
+                    style: const TextStyle(fontSize: 12, color: Colors.white70),
                   ),
                   const SizedBox(width: 16),
-                  const Icon(Icons.account_balance,
-                      size: 12, color: AppColors.textTertiary),
+                  const Icon(
+                    Icons.account_balance,
+                    size: 12,
+                    color: Colors.white54,
+                  ),
                   const SizedBox(width: 4),
                   Text(
                     bankInfo,
-                    style: const TextStyle(
-                      fontSize: 12,
-                      color: AppColors.textTertiary,
-                    ),
+                    style: const TextStyle(fontSize: 12, color: Colors.white70),
                   ),
                 ],
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -551,6 +551,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  showcaseview:
+    dependency: "direct main"
+    description:
+      name: showcaseview
+      sha256: f236c1f44b286e1ba888f8701adca067af92c33e29ea937d0fe9b4a29d4cd41e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: saatdin
 description: "Parametric income insurance for Q-commerce delivery riders."
-publish_to: 'none'
+publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.10.0 <4.0.0'
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -14,6 +14,7 @@ dependencies:
   intl: ^0.20.2
   http: ^1.2.2
   shared_preferences: ^2.3.3
+  showcaseview: ^3.0.0
   flutter_svg: ^2.0.10+1
   geolocator: ^13.0.2
   sensors_plus: ^6.1.1
@@ -38,4 +39,3 @@ flutter:
     - assets/documents/
     - assets/images/
     - assets/images/onboarding-screens/
-

--- a/test/api_service_test.dart
+++ b/test/api_service_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:saatdin/services/api_service.dart';

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:saatdin/screens/home/home_screen.dart';
 
 void main() {
   testWidgets('HomeScreen renders without error', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- merge upstream phase-3 baseline with local rider-focused UX work from stash
- restore richer payouts/profile payment summaries while keeping appearance mode controls
- keep home/coverage/payouts/profile screens aligned with theme mode (dark/light/system)
- set first-launch fallback to light mode while preserving saved user preference
 
- ## Validation
- VS Code diagnostics: no errors in workspace
- verified theme toggle updates UI state (Profile shows currently light when selected)
 
- ## Notes
- excludes local-only files such as .vscode, backend/venv, and draft markdown notes